### PR TITLE
Add InPost Italy delivery service

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -51,6 +51,7 @@ enum class Service {
   POSTNORD,
   ALLEGRO_ONEBOX,
   INPOST,
+  INPOST_IT,
   ORLEN_PACZKA,
 
   // Asia
@@ -96,6 +97,7 @@ fun getDeliveryService(service: Service): DeliveryService? {
     Service.POSTNORD -> PostNordDeliveryService
     Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
     Service.INPOST -> InPostDeliveryService
+    Service.INPOST_IT -> InPostItalyDeliveryService
     Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService
 
     Service.EKART -> EKartDeliveryService

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153479 (tracking)
 // https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153478/Statuses (status codes)
 package dev.itsvic.parceltracker.api

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
@@ -5,11 +5,11 @@ package dev.itsvic.parceltracker.api
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 object InPostItalyDeliveryService : DeliveryService {
   override val nameResource: Int = R.string.service_inpost_it
@@ -19,12 +19,11 @@ object InPostItalyDeliveryService : DeliveryService {
   private const val BASE_URL = "https://api-shipx-it.easypack24.net/v1/"
 
   private val retrofit =
-    Retrofit
-      .Builder()
-      .baseUrl(BASE_URL)
-      .client(api_client)
-      .addConverterFactory(api_factory)
-      .build()
+      Retrofit.Builder()
+          .baseUrl(BASE_URL)
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
 
   private val service = retrofit.create(API::class.java)
 
@@ -34,113 +33,105 @@ object InPostItalyDeliveryService : DeliveryService {
   }
 
   override suspend fun getParcel(
-    trackingId: String,
-    postalCode: String?,
+      trackingId: String,
+      postalCode: String?,
   ): Parcel {
     val response =
-      try {
-        service.getParcel(trackingId)
-      } catch (_: Exception) {
-        throw ParcelNonExistentException()
-      }
+        try {
+          service.getParcel(trackingId)
+        } catch (_: Exception) {
+          throw ParcelNonExistentException()
+        }
 
     return Parcel(
-      response.trackingNumber,
-      eventsToHistory(response.trackingDetails),
-      statusToEnum(response.trackingDetails.firstOrNull()?.status ?: "unknown"),
+        response.trackingNumber,
+        eventsToHistory(response.trackingDetails),
+        statusToEnum(response.trackingDetails.firstOrNull()?.status ?: "unknown"),
     )
   }
 
   private fun statusToEnum(status: String): Status =
-    when (status) {
-      "created" -> Status.Preadvice
+      when (status) {
+        "created" -> Status.Preadvice
 
-      "confirmed" -> Status.InTransit
+        "confirmed" -> Status.InTransit
 
-      "dispatched_by_sender",
-      "dispatched_by_sender_to_pok",
-      "collected_from_sender",
-      -> Status.InTransit
+        "dispatched_by_sender",
+        "dispatched_by_sender_to_pok",
+        "collected_from_sender", -> Status.InTransit
 
-      "taken_by_courier",
-      "taken_by_courier_from_pok",
-      "taken_by_courier_from_customer_service_point",
-      -> Status.PickedUpByCourier
+        "taken_by_courier",
+        "taken_by_courier_from_pok",
+        "taken_by_courier_from_customer_service_point", -> Status.PickedUpByCourier
 
-      "adopted_at_source",
-      "adopted_at_source_branch",
-      "adopted_at_sorting_center",
-      "stack_in_customer_service_point",
-      "stack_in_box_machine",
-      -> Status.InWarehouse
+        "adopted_at_source",
+        "adopted_at_source_branch",
+        "adopted_at_sorting_center",
+        "stack_in_customer_service_point",
+        "stack_in_box_machine", -> Status.InWarehouse
 
-      "sent_from_source_branch",
-      "unstack_from_customer_service_point",
-      "unstack_from_box_machine",
-      -> Status.InTransit
+        "sent_from_source_branch",
+        "unstack_from_customer_service_point",
+        "unstack_from_box_machine", -> Status.InTransit
 
-      "out_for_delivery",
-      "out_for_delivery_to_address",
-      -> Status.OutForDelivery
+        "out_for_delivery",
+        "out_for_delivery_to_address", -> Status.OutForDelivery
 
-      "ready_to_pickup",
-      "ready_to_pickup_from_branch",
-      "ready_to_pickup_from_pok",
-      "courier_avizo_in_customer_service_point",
-      -> Status.AwaitingPickup
+        "ready_to_pickup",
+        "ready_to_pickup_from_branch",
+        "ready_to_pickup_from_pok",
+        "courier_avizo_in_customer_service_point", -> Status.AwaitingPickup
 
-      "pickup_reminder_sent",
-      "pickup_reminder_sent_address",
-      -> Status.PickupTimeEndingSoon
+        "pickup_reminder_sent",
+        "pickup_reminder_sent_address", -> Status.PickupTimeEndingSoon
 
-      "returned_to_sender" -> Status.ReturnedToSender
+        "returned_to_sender" -> Status.ReturnedToSender
 
-      "delay_in_delivery" -> Status.Delayed
+        "delay_in_delivery" -> Status.Delayed
 
-      "redirect_to_box" -> Status.Readdressed
+        "redirect_to_box" -> Status.Readdressed
 
-      "rejected_by_receiver",
-      "undelivered",
-      "undelivered_wrong_address",
-      "undelivered_cod_cash_receiver",
-      "pickup_time_expired",
-      "stack_parcel_pickup_time_expired",
-      "stack_parcel_in_box_machine_pickup_time_expired",
-      "canceled_redirect_to_box",
-      -> Status.DeliveryFailure
+        "rejected_by_receiver",
+        "undelivered",
+        "undelivered_wrong_address",
+        "undelivered_cod_cash_receiver",
+        "pickup_time_expired",
+        "stack_parcel_pickup_time_expired",
+        "stack_parcel_in_box_machine_pickup_time_expired",
+        "canceled_redirect_to_box", -> Status.DeliveryFailure
 
-      "delivered" -> Status.Delivered
+        "delivered" -> Status.Delivered
 
-      else -> logUnknownStatus("InPostIT", status)
-    }
+        else -> logUnknownStatus("InPostIT", status)
+      }
 
   private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
-    details.map { item ->
-      ParcelHistoryItem(
-        item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
-        LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
-        item.agency ?: "",
-      )
-    }
+      details.map { item ->
+        ParcelHistoryItem(
+            item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
+            LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+            item.agency ?: "",
+        )
+      }
 
   private interface API {
     @GET("tracking/{trackingId}")
     suspend fun getParcel(
-      @Path("trackingId") trackingId: String,
+        @Path("trackingId") trackingId: String,
     ): TrackingResponse
   }
 
   @JsonClass(generateAdapter = true)
   internal data class TrackingResponse(
-    @Json(name = "tracking_number") val trackingNumber: String,
-    @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
+      @Json(name = "tracking_number") val trackingNumber: String,
+      @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
   )
 
   @JsonClass(generateAdapter = true)
   internal data class TrackingDetail(
-    @Json(name = "origin_status") val originStatus: String,
-    val status: String,
-    val agency: String?,
-    val datetime: String,
+      @Json(name = "origin_status") val originStatus: String,
+      val status: String,
+      val agency: String?,
+      val datetime: String,
   )
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
@@ -1,0 +1,146 @@
+// https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153479 (tracking)
+// https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153478/Statuses (status codes)
+package dev.itsvic.parceltracker.api
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import dev.itsvic.parceltracker.R
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Path
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object InPostItalyDeliveryService : DeliveryService {
+  override val nameResource: Int = R.string.service_inpost_it
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
+
+  private const val BASE_URL = "https://api-shipx-it.easypack24.net/v1/"
+
+  private val retrofit =
+    Retrofit
+      .Builder()
+      .baseUrl(BASE_URL)
+      .client(api_client)
+      .addConverterFactory(api_factory)
+      .build()
+
+  private val service = retrofit.create(API::class.java)
+
+  override fun acceptsFormat(trackingId: String): Boolean {
+    val inpostRegex = """^\d{24}$""".toRegex()
+    return inpostRegex.matchEntire(trackingId) != null
+  }
+
+  override suspend fun getParcel(
+    trackingId: String,
+    postalCode: String?,
+  ): Parcel {
+    val response =
+      try {
+        service.getParcel(trackingId)
+      } catch (_: Exception) {
+        throw ParcelNonExistentException()
+      }
+
+    return Parcel(
+      response.trackingNumber,
+      eventsToHistory(response.trackingDetails),
+      statusToEnum(response.trackingDetails.firstOrNull()?.status ?: "unknown"),
+    )
+  }
+
+  private fun statusToEnum(status: String): Status =
+    when (status) {
+      "created" -> Status.Preadvice
+
+      "confirmed" -> Status.InTransit
+
+      "dispatched_by_sender",
+      "dispatched_by_sender_to_pok",
+      "collected_from_sender",
+      -> Status.InTransit
+
+      "taken_by_courier",
+      "taken_by_courier_from_pok",
+      "taken_by_courier_from_customer_service_point",
+      -> Status.PickedUpByCourier
+
+      "adopted_at_source",
+      "adopted_at_source_branch",
+      "adopted_at_sorting_center",
+      "stack_in_customer_service_point",
+      "stack_in_box_machine",
+      -> Status.InWarehouse
+
+      "sent_from_source_branch",
+      "unstack_from_customer_service_point",
+      "unstack_from_box_machine",
+      -> Status.InTransit
+
+      "out_for_delivery",
+      "out_for_delivery_to_address",
+      -> Status.OutForDelivery
+
+      "ready_to_pickup",
+      "ready_to_pickup_from_branch",
+      "ready_to_pickup_from_pok",
+      "courier_avizo_in_customer_service_point",
+      -> Status.AwaitingPickup
+
+      "pickup_reminder_sent",
+      "pickup_reminder_sent_address",
+      -> Status.PickupTimeEndingSoon
+
+      "returned_to_sender" -> Status.ReturnedToSender
+
+      "delay_in_delivery" -> Status.Delayed
+
+      "redirect_to_box" -> Status.Readdressed
+
+      "rejected_by_receiver",
+      "undelivered",
+      "undelivered_wrong_address",
+      "undelivered_cod_cash_receiver",
+      "pickup_time_expired",
+      "stack_parcel_pickup_time_expired",
+      "stack_parcel_in_box_machine_pickup_time_expired",
+      "canceled_redirect_to_box",
+      -> Status.DeliveryFailure
+
+      "delivered" -> Status.Delivered
+
+      else -> logUnknownStatus("InPostIT", status)
+    }
+
+  private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
+    details.map { item ->
+      ParcelHistoryItem(
+        item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
+        LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+        item.agency ?: "",
+      )
+    }
+
+  private interface API {
+    @GET("tracking/{trackingId}")
+    suspend fun getParcel(
+      @Path("trackingId") trackingId: String,
+    ): TrackingResponse
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class TrackingResponse(
+    @Json(name = "tracking_number") val trackingNumber: String,
+    @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class TrackingDetail(
+    @Json(name = "origin_status") val originStatus: String,
+    val status: String,
+    val agency: String?,
+    val datetime: String,
+  )
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -44,7 +44,8 @@
   <string name="service_example">بريد تجريبي</string>
   <string name="service_gls_hungary">بريد GLS المجر</string>
   <string name="service_hungarian_post">البريد المجري</string>
-  <string name="service_inpost">بريد InPost</string>
+  <string name="service_inpost">بريد InPost (بولندا)</string>
+  <string name="service_inpost_it">بريد InPost (إيطاليا)</string>
   <string name="service_nova_poshta">بريد Nova</string>
   <string name="service_orlen_paczka">بريد Orlen Paczka (بولندا)</string>
   <string name="service_polish_post">البريد البولندي</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -44,7 +44,8 @@
   <string name="service_example">Corriere d\'esempio</string>
   <string name="service_gls_hungary">GLS Ungheria</string>
   <string name="service_hungarian_post">Poste ungheresi</string>
-  <string name="service_inpost">InPost</string>
+  <string name="service_inpost">InPost (Polonia)</string>
+  <string name="service_inpost_it">InPost</string>
   <string name="service_nova_poshta">Nova Post</string>
   <string name="service_orlen_paczka">Orlen Paczka (Polonia)</string>
   <string name="service_polish_post">Poste polacche</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -43,7 +43,8 @@
   <string name="service_example">Poczta Pokazowa</string>
   <string name="service_gls_hungary">GLS Węgry</string>
   <string name="service_hungarian_post">Poczta Węgierska</string>
-  <string name="service_inpost">InPost</string>
+  <string name="service_inpost">InPost (Polska)</string>
+  <string name="service_inpost_it">InPost (Włochy)</string>
   <string name="service_nova_poshta">Nova Post</string>
   <string name="service_orlen_paczka">Orlen Paczka</string>
   <string name="service_polish_post">Poczta Polska</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -46,7 +46,8 @@
   <string name="service_example">Poștă exemplu</string>
   <string name="service_gls_hungary">GLS Ungaria</string>
   <string name="service_hungarian_post">Poșta Maghiară</string>
-  <string name="service_inpost">InPost</string>
+  <string name="service_inpost">InPost (Polonia)</string>
+  <string name="service_inpost_it">InPost (Italia)</string>
   <string name="service_nova_poshta">Nova Post</string>
   <string name="service_orlen_paczka">Orlen Paczka (Polonia)</string>
   <string name="service_polish_post">Poșta Poloneză</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,8 @@
   <string name="service_gls_hungary">GLS Hungary</string>
   <string name="service_hermes" translatable="false">Hermes</string>
   <string name="service_hungarian_post">Hungarian Post</string>
-  <string name="service_inpost">InPost</string>
+  <string name="service_inpost">InPost (Poland)</string>
+  <string name="service_inpost_it">InPost (Italy)</string>
   <string name="service_nova_poshta">Nova Post</string>
   <string name="service_orlen_paczka">Orlen Paczka (Poland)</string>
   <string name="service_packeta" translatable="false">Packeta</string>


### PR DESCRIPTION
## Summary
- Adds InPost Italy tracking support as a separate delivery service
- Uses the ShipX Italian API (api-shipx-it.easypack24.net/v1/tracking/{id})
## Changes Made
- New InPostItalyDeliveryService.kt — Italian InPost API integration
- Added INPOST_IT to Service enum in Core.kt
- Added service_inpost_it string resources for all locales
- Renamed service_inpost to include "(Poland)" to distinguish both services
- Italian locale shows just "InPost" for the Italian variant (no country suffix needed locally)
## Technical Details
The Italian ShipX API returns a different JSON structure than the Polish service:
- Single object response (not array)
- `tracking_details` with `origin_status` and `status` fields
- Uses the `status` field with documented ShipX status codes shared across markets
- Status history displays the `status` field with formatting (underscores → spaces, first char uppercase) and the `agency` field as location code
## References
- [ShipX Tracking API](https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153479)
- [ShipX Status Codes](https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153478/Statuses)