### PR TITLE
feat: allegro login support for package sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,15 +111,18 @@ dependencies {
   implementation(libs.work.runtime.ktx)
   implementation(libs.kotlinx.coroutines.guava)
   implementation(libs.androidx.browser)
+  implementation(libs.zxing.core)
 
   ksp(libs.room.compiler)
   ksp(libs.moshi.kotlin.codegen)
 
   testImplementation(libs.junit)
+  testImplementation(libs.mockwebserver)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.espresso.core)
   androidTestImplementation(platform(libs.androidx.compose.bom))
   androidTestImplementation(libs.androidx.ui.test.junit4)
   debugImplementation(libs.androidx.ui.tooling)
   debugImplementation(libs.androidx.ui.test.manifest)
+  debugImplementation(libs.chucker)
 }

--- a/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/5.json
+++ b/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/5.json
@@ -1,0 +1,247 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "1fda3b2e663a067a922137502695b929",
+    "entities": [
+      {
+        "tableName": "Parcel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `humanName` TEXT NOT NULL, `parcelId` TEXT NOT NULL, `postalCode` TEXT, `service` TEXT NOT NULL, `isArchived` INTEGER NOT NULL DEFAULT 0, `archivePromptDismissed` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "humanName",
+            "columnName": "humanName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postalCode",
+            "columnName": "postalCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "archivePromptDismissed",
+            "columnName": "archivePromptDismissed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `status` TEXT NOT NULL, `lastChange` INTEGER NOT NULL, PRIMARY KEY(`parcelId`))",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChange",
+            "columnName": "lastChange",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelHistoryItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `parcelId` INTEGER NOT NULL, `description` TEXT NOT NULL, `time` TEXT NOT NULL, `location` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "AllegroPackageLink",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `accountKey` TEXT NOT NULL, `remotePackageId` TEXT NOT NULL, `carrierId` TEXT NOT NULL, `carrierName` TEXT NOT NULL, `waybill` TEXT NOT NULL, `statusText` TEXT NOT NULL, `readyForPickup` INTEGER NOT NULL, `statusChangedAt` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, PRIMARY KEY(`parcelId`), FOREIGN KEY(`parcelId`) REFERENCES `Parcel`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "accountKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePackageId",
+            "columnName": "remotePackageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierId",
+            "columnName": "carrierId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierName",
+            "columnName": "carrierName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "waybill",
+            "columnName": "waybill",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusText",
+            "columnName": "statusText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readyForPickup",
+            "columnName": "readyForPickup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusChangedAt",
+            "columnName": "statusChangedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AllegroPackageLink_accountKey_remotePackageId",
+            "unique": true,
+            "columnNames": [
+              "accountKey",
+              "remotePackageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_remotePackageId` ON `${TABLE_NAME}` (`accountKey`, `remotePackageId`)"
+          },
+          {
+            "name": "index_AllegroPackageLink_accountKey_waybill",
+            "unique": false,
+            "columnNames": [
+              "accountKey",
+              "waybill"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_waybill` ON `${TABLE_NAME}` (`accountKey`, `waybill`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Parcel",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parcelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1fda3b2e663a067a922137502695b929')"
+    ]
+  }
+}

--- a/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/6.json
+++ b/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/6.json
@@ -1,0 +1,261 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "6b43bf20df88a995e74b5f13d2f4be63",
+    "entities": [
+      {
+        "tableName": "Parcel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `humanName` TEXT NOT NULL, `parcelId` TEXT NOT NULL, `postalCode` TEXT, `service` TEXT NOT NULL, `isArchived` INTEGER NOT NULL DEFAULT 0, `archivePromptDismissed` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "humanName",
+            "columnName": "humanName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postalCode",
+            "columnName": "postalCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "archivePromptDismissed",
+            "columnName": "archivePromptDismissed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `status` TEXT NOT NULL, `lastChange` INTEGER NOT NULL, PRIMARY KEY(`parcelId`))",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChange",
+            "columnName": "lastChange",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelHistoryItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `parcelId` INTEGER NOT NULL, `description` TEXT NOT NULL, `time` TEXT NOT NULL, `location` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "AllegroPackageLink",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `accountKey` TEXT NOT NULL, `remotePackageId` TEXT NOT NULL, `carrierId` TEXT NOT NULL, `carrierName` TEXT NOT NULL, `waybill` TEXT NOT NULL, `statusText` TEXT NOT NULL, `readyForPickup` INTEGER NOT NULL, `pickupCode` TEXT NOT NULL DEFAULT '', `pickupPhoneNumber` TEXT NOT NULL DEFAULT '', `statusChangedAt` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, PRIMARY KEY(`parcelId`), FOREIGN KEY(`parcelId`) REFERENCES `Parcel`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "accountKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePackageId",
+            "columnName": "remotePackageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierId",
+            "columnName": "carrierId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierName",
+            "columnName": "carrierName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "waybill",
+            "columnName": "waybill",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusText",
+            "columnName": "statusText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readyForPickup",
+            "columnName": "readyForPickup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pickupCode",
+            "columnName": "pickupCode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "pickupPhoneNumber",
+            "columnName": "pickupPhoneNumber",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "statusChangedAt",
+            "columnName": "statusChangedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AllegroPackageLink_accountKey_remotePackageId",
+            "unique": true,
+            "columnNames": [
+              "accountKey",
+              "remotePackageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_remotePackageId` ON `${TABLE_NAME}` (`accountKey`, `remotePackageId`)"
+          },
+          {
+            "name": "index_AllegroPackageLink_accountKey_waybill",
+            "unique": false,
+            "columnNames": [
+              "accountKey",
+              "waybill"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_waybill` ON `${TABLE_NAME}` (`accountKey`, `waybill`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Parcel",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parcelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6b43bf20df88a995e74b5f13d2f4be63')"
+    ]
+  }
+}

--- a/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/7.json
+++ b/app/schemas/dev.itsvic.parceltracker.db.AppDatabase/7.json
@@ -1,0 +1,282 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "61445e379525734a84b3426849f64ae6",
+    "entities": [
+      {
+        "tableName": "Parcel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `humanName` TEXT NOT NULL, `parcelId` TEXT NOT NULL, `postalCode` TEXT, `service` TEXT NOT NULL, `isArchived` INTEGER NOT NULL DEFAULT 0, `archivePromptDismissed` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "humanName",
+            "columnName": "humanName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postalCode",
+            "columnName": "postalCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "archivePromptDismissed",
+            "columnName": "archivePromptDismissed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `status` TEXT NOT NULL, `lastChange` INTEGER NOT NULL, PRIMARY KEY(`parcelId`))",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChange",
+            "columnName": "lastChange",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        }
+      },
+      {
+        "tableName": "ParcelHistoryItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `parcelId` INTEGER NOT NULL, `description` TEXT NOT NULL, `time` TEXT NOT NULL, `location` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "AllegroPackageLink",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parcelId` INTEGER NOT NULL, `accountKey` TEXT NOT NULL, `remotePackageId` TEXT NOT NULL, `carrierId` TEXT NOT NULL, `carrierName` TEXT NOT NULL, `waybill` TEXT NOT NULL, `statusText` TEXT NOT NULL, `readyForPickup` INTEGER NOT NULL, `pickupCode` TEXT NOT NULL DEFAULT '', `pickupPhoneNumber` TEXT NOT NULL DEFAULT '', `multiboxGroupId` TEXT NOT NULL DEFAULT '', `multiboxIndex` TEXT NOT NULL DEFAULT '', `bundledWith` TEXT NOT NULL DEFAULT '', `statusChangedAt` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, PRIMARY KEY(`parcelId`), FOREIGN KEY(`parcelId`) REFERENCES `Parcel`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parcelId",
+            "columnName": "parcelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "accountKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePackageId",
+            "columnName": "remotePackageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierId",
+            "columnName": "carrierId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carrierName",
+            "columnName": "carrierName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "waybill",
+            "columnName": "waybill",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusText",
+            "columnName": "statusText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readyForPickup",
+            "columnName": "readyForPickup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pickupCode",
+            "columnName": "pickupCode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "pickupPhoneNumber",
+            "columnName": "pickupPhoneNumber",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "multiboxGroupId",
+            "columnName": "multiboxGroupId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "multiboxIndex",
+            "columnName": "multiboxIndex",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "bundledWith",
+            "columnName": "bundledWith",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "statusChangedAt",
+            "columnName": "statusChangedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parcelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AllegroPackageLink_accountKey_remotePackageId",
+            "unique": true,
+            "columnNames": [
+              "accountKey",
+              "remotePackageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_remotePackageId` ON `${TABLE_NAME}` (`accountKey`, `remotePackageId`)"
+          },
+          {
+            "name": "index_AllegroPackageLink_accountKey_waybill",
+            "unique": false,
+            "columnNames": [
+              "accountKey",
+              "waybill"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AllegroPackageLink_accountKey_waybill` ON `${TABLE_NAME}` (`accountKey`, `waybill`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Parcel",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parcelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '61445e379525734a84b3426849f64ae6')"
+    ]
+  }
+}

--- a/app/src/debug/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
+++ b/app/src/debug/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import android.content.Context
+import com.chuckerteam.chucker.api.ChuckerInterceptor
+import okhttp3.Interceptor
+
+internal fun createAllegroDebugInterceptor(context: Context): Interceptor {
+  val chucker =
+      ChuckerInterceptor.Builder(context)
+          .maxContentLength(5_000_000L)
+          .redactHeaders("Authorization", "Cookie", "Set-Cookie", "x-wdctx")
+          .alwaysReadResponseBody(true)
+          .createShortcut(true)
+          .build()
+
+  return Interceptor { chain ->
+    val request = chain.request()
+    val isPackageSync =
+        request.url.encodedPath == "/packages/summary" ||
+            (request.url.encodedPath == "/mobile/render" &&
+                request.url.queryParameter("route")?.contains("szczegoly-dostawy") != true)
+    if (isPackageSync) chucker.intercept(chain) else chain.proceed(request)
+  }
+}

--- a/app/src/debug/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
+++ b/app/src/debug/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
@@ -18,8 +18,8 @@ internal fun createAllegroDebugInterceptor(context: Context): Interceptor {
     val request = chain.request()
     val isPackageSync =
         request.url.encodedPath == "/packages/summary" ||
-            (request.url.encodedPath == "/mobile/render" &&
-                request.url.queryParameter("route")?.contains("szczegoly-dostawy") != true)
+            request.url.encodedPath.startsWith("/packages/carrier/") ||
+            request.url.encodedPath == "/mobile/render"
     if (isPackageSync) chucker.intercept(chain) else chain.proceed(request)
   }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -46,10 +47,15 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.squareup.moshi.JsonDataException
+import dev.itsvic.parceltracker.allegro.AllegroPickupDetails
+import dev.itsvic.parceltracker.allegro.AllegroRepository
+import dev.itsvic.parceltracker.allegro.AllegroSessionStore
+import dev.itsvic.parceltracker.allegro.allegroAccountKey
 import dev.itsvic.parceltracker.api.APIKeyMissingException
 import dev.itsvic.parceltracker.api.Parcel as APIParcel
 import dev.itsvic.parceltracker.api.ParcelHistoryItem
 import dev.itsvic.parceltracker.api.ParcelNonExistentException
+import dev.itsvic.parceltracker.api.Service
 import dev.itsvic.parceltracker.api.Status
 import dev.itsvic.parceltracker.api.getParcel
 import dev.itsvic.parceltracker.db.Parcel
@@ -57,6 +63,7 @@ import dev.itsvic.parceltracker.db.ParcelStatus
 import dev.itsvic.parceltracker.db.ParcelWithStatus
 import dev.itsvic.parceltracker.db.deleteParcel
 import dev.itsvic.parceltracker.db.demoModeParcels
+import dev.itsvic.parceltracker.ui.components.PickupCodeDialog
 import dev.itsvic.parceltracker.ui.theme.ParcelTrackerTheme
 import dev.itsvic.parceltracker.ui.views.AddEditParcelView
 import dev.itsvic.parceltracker.ui.views.HomeView
@@ -64,8 +71,10 @@ import dev.itsvic.parceltracker.ui.views.ParcelView
 import dev.itsvic.parceltracker.ui.views.SettingsView
 import java.time.LocalDateTime
 import java.time.ZoneId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import okio.IOException
 
@@ -189,13 +198,26 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
     composable<SettingsPage> { SettingsView(onBackPressed = { navController.popBackStack() }) }
 
     composable<ParcelPage> { backStackEntry ->
+      val destinationScope = rememberCoroutineScope()
+      val resources = LocalResources.current
       val route: ParcelPage = backStackEntry.toRoute()
       val parcelWithStatus: ParcelWithStatus? =
           if (demoMode) demoModeParcels[route.parcelDbId]
           else db.parcelDao().getWithStatusById(route.parcelDbId).collectAsState(null).value
       val dbHistory: List<dev.itsvic.parceltracker.db.ParcelHistoryItem> by
           db.parcelHistoryDao().getAllById(route.parcelDbId).collectAsState(listOf())
+      val allegroLink by
+          db.allegroPackageLinkDao()
+              .observeByParcelId(route.parcelDbId)
+              .collectAsState(initial = null)
       var apiParcel: APIParcel? by remember { mutableStateOf(null) }
+      var pickupDetails: AllegroPickupDetails? by
+          remember(route.parcelDbId) { mutableStateOf(null) }
+      var pickupCodeLoading by remember(route.parcelDbId) { mutableStateOf(false) }
+      val activeAllegroAccountKey =
+          remember(allegroLink?.accountKey) {
+            AllegroSessionStore(context).load()?.let { allegroAccountKey(it.username) }
+          }
       val networkFailureDetail = stringResource(R.string.network_failure_detail)
       val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
       val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
@@ -218,7 +240,7 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
               apiParcel =
                   context.getParcel(dbParcel.parcelId, dbParcel.postalCode, dbParcel.service)
 
-              if (!demoMode) {
+              if (!demoMode && dbParcel.service != Service.ALLEGRO_ACCOUNT) {
                 // update parcel status
                 val zone = ZoneId.systemDefault()
                 val lastChange = apiParcel!!.history.first().time.atZone(zone).toInstant()
@@ -234,8 +256,10 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
                   db.parcelStatusDao().update(status)
                 }
               }
+            } catch (error: CancellationException) {
+              throw error
             } catch (e: IOException) {
-              Log.w("MainActivity", "Failed fetch: $e")
+              Log.w("MainActivity", "Failed to fetch parcel")
               apiParcel = apiParcelError(networkFailureDetail, Status.NetworkFailure)
             } catch (_: ParcelNonExistentException) {
               apiParcel = apiParcelError(parcelDoesntExistDetail, Status.NoData)
@@ -282,6 +306,15 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
               dbParcel.service,
               dbParcel.isArchived,
               dbParcel.archivePromptDismissed,
+              canEdit = allegroLink == null,
+              showPickupCode =
+                  allegroLink?.let {
+                    it.readyForPickup &&
+                        it.accountKey == activeAllegroAccountKey &&
+                        it.waybill == dbParcel.parcelId &&
+                        !dbParcel.isArchived
+                  } == true,
+              pickupCodeLoading = pickupCodeLoading,
               onBackPressed = { navController.popBackStack() },
               onEdit = { navController.navigate(EditParcelPage(dbParcel.id)) },
               onDelete = {
@@ -324,7 +357,37 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
                   db.parcelDao().update(dbParcel.copy(archivePromptDismissed = true))
                 }
               },
+              onShowPickupCode = {
+                val link = allegroLink ?: return@ParcelView
+                pickupCodeLoading = true
+                destinationScope.launch {
+                  try {
+                    pickupDetails =
+                        withContext(Dispatchers.IO) {
+                          AllegroRepository(context).fetchPickupDetails(link)
+                        }
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (error: Exception) {
+                    Toast.makeText(
+                            context,
+                            resources.getString(
+                                R.string.pickup_code_fetch_failed,
+                                error.message ?: resources.getString(R.string.error_unknown),
+                            ),
+                            Toast.LENGTH_LONG,
+                        )
+                        .show()
+                  } finally {
+                    pickupCodeLoading = false
+                  }
+                }
+              },
           )
+
+      pickupDetails?.let { details ->
+        PickupCodeDialog(details = details, onDismiss = { pickupDetails = null })
+      }
     }
 
     composable<AddParcelPage> {

--- a/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
@@ -49,8 +49,6 @@ import androidx.navigation.toRoute
 import com.squareup.moshi.JsonDataException
 import dev.itsvic.parceltracker.allegro.AllegroPickupDetails
 import dev.itsvic.parceltracker.allegro.AllegroRepository
-import dev.itsvic.parceltracker.allegro.AllegroSessionStore
-import dev.itsvic.parceltracker.allegro.allegroAccountKey
 import dev.itsvic.parceltracker.api.APIKeyMissingException
 import dev.itsvic.parceltracker.api.Parcel as APIParcel
 import dev.itsvic.parceltracker.api.ParcelHistoryItem
@@ -214,10 +212,6 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
       var pickupDetails: AllegroPickupDetails? by
           remember(route.parcelDbId) { mutableStateOf(null) }
       var pickupCodeLoading by remember(route.parcelDbId) { mutableStateOf(false) }
-      val activeAllegroAccountKey =
-          remember(allegroLink?.accountKey) {
-            AllegroSessionStore(context).load()?.let { allegroAccountKey(it.username) }
-          }
       val networkFailureDetail = stringResource(R.string.network_failure_detail)
       val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
       val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
@@ -309,10 +303,7 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
               canEdit = allegroLink == null,
               showPickupCode =
                   allegroLink?.let {
-                    it.readyForPickup &&
-                        it.accountKey == activeAllegroAccountKey &&
-                        it.waybill == dbParcel.parcelId &&
-                        !dbParcel.isArchived
+                    it.readyForPickup && it.waybill == dbParcel.parcelId && !dbParcel.isArchived
                   } == true,
               pickupCodeLoading = pickupCodeLoading,
               onBackPressed = { navController.popBackStack() },
@@ -359,25 +350,43 @@ fun ParcelAppNavigation(parcelToOpen: Int) {
               },
               onShowPickupCode = {
                 val link = allegroLink ?: return@ParcelView
+                val hasStoredDetails =
+                    link.pickupCode.isNotBlank() || link.pickupPhoneNumber.isNotBlank()
+                if (hasStoredDetails) {
+                  pickupDetails =
+                      AllegroPickupDetails(
+                          waybill = link.waybill,
+                          carrierId = link.carrierId,
+                          code = link.pickupCode,
+                          phoneNumber = link.pickupPhoneNumber,
+                      )
+                }
                 pickupCodeLoading = true
                 destinationScope.launch {
                   try {
-                    pickupDetails =
+                    val fetched =
                         withContext(Dispatchers.IO) {
                           AllegroRepository(context).fetchPickupDetails(link)
                         }
+                    pickupDetails =
+                        fetched.copy(
+                            code = fetched.code.ifBlank { link.pickupCode },
+                            phoneNumber = fetched.phoneNumber.ifBlank { link.pickupPhoneNumber },
+                        )
                   } catch (error: CancellationException) {
                     throw error
                   } catch (error: Exception) {
-                    Toast.makeText(
-                            context,
-                            resources.getString(
-                                R.string.pickup_code_fetch_failed,
-                                error.message ?: resources.getString(R.string.error_unknown),
-                            ),
-                            Toast.LENGTH_LONG,
-                        )
-                        .show()
+                    if (!hasStoredDetails) {
+                      Toast.makeText(
+                              context,
+                              resources.getString(
+                                  R.string.pickup_code_fetch_failed,
+                                  error.message ?: resources.getString(R.string.error_unknown),
+                              ),
+                              Toast.LENGTH_LONG,
+                          )
+                          .show()
+                    }
                   } finally {
                     pickupCodeLoading = false
                   }

--- a/app/src/main/java/dev/itsvic/parceltracker/NotificationWorker.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/NotificationWorker.kt
@@ -11,10 +11,13 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import dev.itsvic.parceltracker.allegro.AllegroRepository
+import dev.itsvic.parceltracker.api.Service
 import dev.itsvic.parceltracker.api.getParcel
 import dev.itsvic.parceltracker.db.ParcelStatus
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -31,14 +34,23 @@ class NotificationWorker(context: Context, params: WorkerParameters) :
     Log.d("NotificationWorker", "I ran!")
 
     withContext(Dispatchers.IO) {
+      try {
+        AllegroRepository(applicationContext).sync(notifyChanges = true)
+      } catch (error: CancellationException) {
+        throw error
+      } catch (e: Exception) {
+        Log.w("NotificationWorker", "Failed to sync Allegro packages", e)
+      }
+
       val parcels = parcelDao.getAllNonArchivedWithStatusAsync()
-      Log.d("NotificationWorker", "Got parcels: $parcels")
+      Log.d("NotificationWorker", "Got ${parcels.size} parcels")
 
       for (parcelWithStatus in parcels) {
         val parcel = parcelWithStatus.parcel
+        if (parcel.service == Service.ALLEGRO_ACCOUNT) continue
         val oldStatus = parcelWithStatus.status
 
-        Log.d("NotificationWorker", "Fetching parcel status for $parcel")
+        Log.d("NotificationWorker", "Fetching parcel status for local parcel ${parcel.id}")
         val apiParcel =
             try {
               applicationContext.getParcel(parcel.parcelId, parcel.postalCode, parcel.service)

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroClient.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroClient.kt
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import java.util.concurrent.TimeUnit
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
+
+internal class AllegroClient(
+    session: AllegroSession? = null,
+    clientBuilder: OkHttpClient.Builder = OkHttpClient.Builder(),
+    debugInterceptor: Interceptor? = null,
+    private val allegroUrl: HttpUrl = "https://allegro.pl/".toHttpUrl(),
+    private val edgeUrl: HttpUrl = "https://edge.allegro.pl/".toHttpUrl(),
+) {
+  private val cookies = CapturingCookieJar()
+  private val client =
+      clientBuilder
+          .apply { debugInterceptor?.let(::addInterceptor) }
+          .cookieJar(cookies)
+          .followRedirects(false)
+          .callTimeout(20, TimeUnit.SECONDS)
+          .build()
+  private val moshi = Moshi.Builder().build()
+  private val credentialsAdapter = moshi.adapter(CredentialsRequest::class.java)
+  private val loginAdapter = moshi.adapter(LoginResponse::class.java)
+  private val anyAdapter = moshi.adapter(Any::class.java)
+  var session: AllegroSession? = session
+    private set
+
+  init {
+    session?.let {
+      cookies.seed("wdctx", it.wdctx)
+      cookies.seed("datadome", it.datadome)
+      it.qxlsessid?.let { value -> cookies.seed("QXLSESSID", value) }
+    }
+  }
+
+  suspend fun login(username: String, password: String): AllegroSession {
+    cookies.clear()
+    val check =
+        execute(
+            Request.Builder()
+                .url(allegroUrl.newBuilder().addPathSegment("client-check").build())
+                .header("User-Agent", CLIENT_CHECK_USER_AGENT)
+                .head()
+                .build())
+    if (check.status !in 200..299) {
+      throw AllegroAuthenticationException(
+          "Allegro client check failed. This connection may have been rejected.", check.status)
+    }
+    val wdctx = cookies.value("wdctx")
+    val datadome = cookies.value("datadome")
+    if (wdctx.isNullOrBlank() || datadome.isNullOrBlank()) {
+      throw AllegroAuthenticationException("Allegro did not issue the cookies required to log in.")
+    }
+
+    val initialization =
+        execute(
+            requestBuilder(
+                    edgeUrl
+                        .newBuilder()
+                        .addPathSegments("authentication/initialization/mobile")
+                        .build(),
+                    authHeaders(wdctx, datadome),
+                )
+                .post(ByteArray(0).toRequestBody(null))
+                .build())
+    if (initialization.status !in 200..299) {
+      throw AllegroAuthenticationException(
+          "Allegro login initialization failed (HTTP ${initialization.status}).",
+          initialization.status,
+      )
+    }
+    val qxlsessid = cookies.value("QXLSESSID")
+    val currentDatadome = cookies.value("datadome") ?: datadome
+    if (qxlsessid.isNullOrBlank()) {
+      throw AllegroAuthenticationException("Allegro did not initialize the login session.")
+    }
+
+    val body = credentialsAdapter.toJson(CredentialsRequest(username, password))
+    val verification =
+        execute(
+            requestBuilder(
+                    edgeUrl
+                        .newBuilder()
+                        .addPathSegments("authentication/credentials/mobile/verification")
+                        .build(),
+                    authHeaders(wdctx, currentDatadome, qxlsessid),
+                )
+                .post(body.toRequestBody(JSON_MEDIA_TYPE))
+                .build())
+    if (verification.status != 200) {
+      throw AllegroAuthenticationException(
+          "Login failed (HTTP ${verification.status}). Check your credentials or account verification requirements.",
+          verification.status,
+      )
+    }
+    val response =
+        verification.body?.let(loginAdapter::fromJson)
+            ?: throw AllegroAuthenticationException("Allegro returned an invalid login response.")
+    if (response.accessToken.isNullOrBlank()) {
+      throw AllegroAuthenticationException(
+          "Allegro did not return an access token. This account may require a CAPTCHA or another verification step.")
+    }
+
+    return AllegroSession(
+            username = response.username ?: username,
+            accessToken = response.accessToken,
+            accessTokenExpiration = response.accessTokenExpiration?.toString(),
+            wdctx = cookies.value("wdctx") ?: wdctx,
+            datadome = cookies.value("datadome") ?: currentDatadome,
+            qxlsessid = cookies.value("QXLSESSID") ?: qxlsessid,
+        )
+        .also { session = it }
+  }
+
+  suspend fun fetchDashboard(): List<AllegroPackage> {
+    getJson("packages/summary", SUMMARY_MEDIA_TYPE)
+    var lastError: AllegroException? = null
+    listOf(PACKAGES_ROUTE, LEGACY_PACKAGES_ROUTE).forEach { route ->
+      try {
+        val payload = getRenderJson(route)
+        val errorCode = mboxErrorCode(payload)
+        if (errorCode == null) return AllegroParser.parsePackages(payload)
+        lastError = AllegroException("Allegro returned a package-list error page.", errorCode)
+      } catch (error: AllegroException) {
+        lastError = error
+        if (error.statusCode !in FALLBACK_STATUS_CODES) throw error
+      }
+    }
+    throw lastError ?: AllegroException("No Allegro package route is available.")
+  }
+
+  suspend fun fetchPackageDetails(packageItem: AllegroPackage): AllegroPackage {
+    val carrierId = packageItem.carrierId.ifBlank { carrierId(packageItem.carrier) }
+    val tracking = packageItem.trackingNumber.ifBlank { packageItem.packageId }
+    if (carrierId.isBlank() || tracking.isBlank()) {
+      throw AllegroException("This package has no carrier or tracking number.")
+    }
+    val route =
+        PACKAGES_ROUTE +
+            "/szczegoly-dostawy?carrierId=" +
+            encodeQueryValue(carrierId) +
+            "&waybill=" +
+            encodeQueryValue(tracking)
+    val payload = getRenderJson(route)
+    mboxErrorCode(payload)?.let {
+      throw AllegroException("Allegro returned a package-details error page.", it)
+    }
+    return AllegroParser.parsePackageDetails(payload, packageItem)
+  }
+
+  suspend fun fetchPickupDetails(carrierId: String, waybill: String): AllegroPickupDetails {
+    if (carrierId.isBlank() || waybill.isBlank()) {
+      throw AllegroException("This package has no carrier or tracking number.")
+    }
+    val url =
+        edgeUrl
+            .newBuilder()
+            .addPathSegments("packages/carrier")
+            .addPathSegment(carrierId)
+            .addPathSegment("waybill")
+            .addPathSegment(waybill)
+            .addPathSegment("pickup-details")
+            .build()
+    val payload = apiJson(url, PICKUP_MEDIA_TYPE)
+    val responseWaybill = payload["waybill"]?.toString().orEmpty()
+    val responseCarrier = payload["carrierId"]?.toString().orEmpty()
+    if (responseWaybill.isNotBlank() && !responseWaybill.equals(waybill, ignoreCase = true)) {
+      throw AllegroException("Allegro returned pickup details for a different package.")
+    }
+    if (responseCarrier.isNotBlank() && !responseCarrier.equals(carrierId, ignoreCase = true)) {
+      throw AllegroException("Allegro returned pickup details for a different carrier.")
+    }
+    val details =
+        AllegroPickupDetails(
+            waybill = responseWaybill.ifBlank { waybill },
+            carrierId = responseCarrier.ifBlank { carrierId },
+            carrierName = payload["carrierName"]?.toString().orEmpty(),
+            code = payload["formattedCode"]?.toString().orEmpty(),
+            phoneNumber = payload["formattedPhoneNumber"]?.toString().orEmpty(),
+            qrPayload = payload["qrCode"]?.toString().orEmpty(),
+        )
+    if (details.code.isBlank() && details.phoneNumber.isBlank() && details.qrPayload.isBlank()) {
+      throw AllegroException("Allegro did not return pickup credentials for this package.")
+    }
+    return details
+  }
+
+  private suspend fun getRenderJson(route: String): Map<*, *> {
+    val url =
+        edgeUrl
+            .newBuilder()
+            .addPathSegments("mobile/render")
+            .addQueryParameter("route", route)
+            .build()
+    return apiJson(url, RENDER_MEDIA_TYPE)
+  }
+
+  private suspend fun getJson(path: String, accept: String): Map<*, *> =
+      apiJson(edgeUrl.newBuilder().addPathSegments(path).build(), accept)
+
+  private suspend fun apiJson(url: HttpUrl, accept: String): Map<*, *> {
+    val current =
+        session ?: throw AllegroSessionExpiredException("Log in to your Allegro account first.")
+    val response = execute(requestBuilder(url, apiHeaders(current, accept)).get().build())
+    if (response.status == 401 || response.status == 403) {
+      throw AllegroSessionExpiredException(
+          "Your Allegro session expired. Log in again.", response.status)
+    }
+    if (response.status !in 200..299) {
+      throw AllegroException("Allegro request failed (HTTP ${response.status}).", response.status)
+    }
+    refreshSessionCookies()
+    val payload =
+        response.body?.let(anyAdapter::fromJson)
+            ?: throw AllegroException("Allegro returned an empty response.", response.status)
+    return payload as? Map<*, *>
+        ?: throw AllegroException("Allegro returned an unexpected response.", response.status)
+  }
+
+  private suspend fun execute(request: Request): HttpResult =
+      client.newCall(request).executeAsync().use { response ->
+        HttpResult(response.code, response.body.string())
+      }
+
+  private fun refreshSessionCookies() {
+    session =
+        session?.copy(
+            wdctx = cookies.value("wdctx") ?: session!!.wdctx,
+            datadome = cookies.value("datadome") ?: session!!.datadome,
+            qxlsessid = cookies.value("QXLSESSID") ?: session!!.qxlsessid,
+        )
+  }
+
+  private fun requestBuilder(url: HttpUrl, headers: Map<String, String>): Request.Builder =
+      Request.Builder().url(url).apply { headers.forEach(::header) }
+
+  private fun authHeaders(
+      wdctx: String,
+      datadome: String,
+      qxlsessid: String? = null,
+  ): Map<String, String> =
+      commonHeaders("application/json") +
+          mapOf(
+              "Cookie" to
+                  buildString {
+                    append("datadome=$datadome")
+                    qxlsessid?.let { append("; QXLSESSID=$it") }
+                  },
+              "x-wdctx" to wdctx,
+          )
+
+  private fun apiHeaders(session: AllegroSession, accept: String): Map<String, String> =
+      commonHeaders(accept) +
+          mapOf(
+              "Authorization" to "Bearer ${session.accessToken}",
+              "Cookie" to "datadome=${session.datadome}",
+              "x-wdctx" to session.wdctx,
+          )
+
+  private fun commonHeaders(accept: String) =
+      mapOf(
+          "Accept" to accept,
+          "Accept-Language" to "en-US",
+          "Content-Type" to accept,
+          "User-Agent" to USER_AGENT,
+      )
+
+  private fun mboxErrorCode(value: Any?): Int? {
+    if (value is Map<*, *>) {
+      if (value["isErrorPage"] == true) {
+        return (value["errorCode"] as? Number)?.toInt()
+            ?: value["errorCode"]?.toString()?.toIntOrNull()
+            ?: 500
+      }
+      value.values.forEach {
+        mboxErrorCode(it)?.let { code ->
+          return code
+        }
+      }
+    } else if (value is List<*>) {
+      value.forEach {
+        mboxErrorCode(it)?.let { code ->
+          return code
+        }
+      }
+    }
+    return null
+  }
+
+  private fun carrierId(carrier: String): String =
+      when (carrier.lowercase()) {
+        "allegro",
+        "allegro one",
+        "allegro one box" -> "ALLEGRO"
+        "inpost" -> "INPOST"
+        else -> carrier.uppercase().replace(' ', '_')
+      }
+
+  private fun encodeQueryValue(value: String): String =
+      java.net.URLEncoder.encode(value, Charsets.UTF_8.name())
+
+  @JsonClass(generateAdapter = true)
+  internal data class CredentialsRequest(val login: String, val password: String)
+
+  @JsonClass(generateAdapter = true)
+  internal data class LoginResponse(
+      val accessToken: String? = null,
+      val accessTokenExpiration: Any? = null,
+      val username: String? = null,
+  )
+
+  private data class HttpResult(val status: Int, val body: String?)
+
+  private class CapturingCookieJar : CookieJar {
+    private val values = mutableMapOf<String, String>()
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+      cookies.forEach { values[it.name.lowercase()] = it.value }
+    }
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> = emptyList()
+
+    fun seed(name: String, value: String) {
+      values[name.lowercase()] = value
+    }
+
+    fun value(name: String): String? = values[name.lowercase()]
+
+    fun clear() = values.clear()
+  }
+
+  companion object {
+    private const val CLIENT_CHECK_USER_AGENT = "okhttp/4.12.0"
+    private const val USER_AGENT =
+        "pl.allegro/9.19.1 (Client-Id e97de40c-0b60-4e81-808b-8eef2aa3cf3b) Android/14 (motorola XT2301-4)"
+    private const val PACKAGES_ROUTE = "https://allegro.pl/moje-allegro/zakupy/moje-przesylki"
+    private const val LEGACY_PACKAGES_ROUTE = "$PACKAGES_ROUTE/app"
+    private const val SUMMARY_MEDIA_TYPE = "application/vnd.allegro.internal.v2+json"
+    private const val RENDER_MEDIA_TYPE = "application/vnd.allegro.internal.v1+json"
+    private const val PICKUP_MEDIA_TYPE = "application/vnd.allegro.beta.v1+json"
+    private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    private val FALLBACK_STATUS_CODES = setOf(400, 404, 405, 406, 410, 422)
+  }
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroClient.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroClient.kt
@@ -4,6 +4,7 @@ package dev.itsvic.parceltracker.allegro
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.withTimeout
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
@@ -214,14 +215,18 @@ internal class AllegroClient(
     val current =
         session ?: throw AllegroSessionExpiredException("Log in to your Allegro account first.")
     val response = execute(requestBuilder(url, apiHeaders(current, accept)).get().build())
-    if (response.status == 401 || response.status == 403) {
+    refreshSessionCookies()
+    if (response.status == 401) {
       throw AllegroSessionExpiredException(
           "Your Allegro session expired. Log in again.", response.status)
+    }
+    if (response.status == 403) {
+      throw AllegroException(
+          "Allegro temporarily blocked the request. Try syncing again later.", response.status)
     }
     if (response.status !in 200..299) {
       throw AllegroException("Allegro request failed (HTTP ${response.status}).", response.status)
     }
-    refreshSessionCookies()
     val payload =
         response.body?.let(anyAdapter::fromJson)
             ?: throw AllegroException("Allegro returned an empty response.", response.status)
@@ -230,8 +235,10 @@ internal class AllegroClient(
   }
 
   private suspend fun execute(request: Request): HttpResult =
-      client.newCall(request).executeAsync().use { response ->
-        HttpResult(response.code, response.body.string())
+      withTimeout(REQUEST_TIMEOUT_MILLIS) {
+        client.newCall(request).executeAsync().use { response ->
+          HttpResult(response.code, response.body.string())
+        }
       }
 
   private fun refreshSessionCookies() {
@@ -352,5 +359,6 @@ internal class AllegroClient(
     private const val PICKUP_MEDIA_TYPE = "application/vnd.allegro.beta.v1+json"
     private val JSON_MEDIA_TYPE = "application/json".toMediaType()
     private val FALLBACK_STATUS_CODES = setOf(400, 404, 405, 406, 410, 422)
+    private const val REQUEST_TIMEOUT_MILLIS = 25_000L
   }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroModels.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroModels.kt
@@ -23,6 +23,10 @@ data class AllegroPackage(
     val pickupPoint: String = "",
     val readyForPickup: Boolean = false,
     val carrierId: String = "",
+    val pickupCode: String = "",
+    val pickupPhoneNumber: String = "",
+    val multiboxGroupId: String = "",
+    val multiboxIndex: String = "",
     val history: List<AllegroTrackingEvent> = emptyList(),
 )
 

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroModels.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroModels.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AllegroSession(
+    val username: String,
+    val accessToken: String,
+    val accessTokenExpiration: String? = null,
+    val wdctx: String,
+    val datadome: String,
+    val qxlsessid: String? = null,
+)
+
+data class AllegroPackage(
+    val packageId: String,
+    val title: String,
+    val status: String,
+    val carrier: String = "",
+    val trackingNumber: String = "",
+    val eta: String = "",
+    val pickupPoint: String = "",
+    val readyForPickup: Boolean = false,
+    val carrierId: String = "",
+    val history: List<AllegroTrackingEvent> = emptyList(),
+)
+
+data class AllegroTrackingEvent(val status: String, val timestamp: String = "")
+
+data class AllegroPickupDetails(
+    val waybill: String,
+    val carrierId: String,
+    val carrierName: String = "",
+    val code: String = "",
+    val phoneNumber: String = "",
+    val qrPayload: String = "",
+)
+
+open class AllegroException(message: String, val statusCode: Int? = null) : Exception(message)
+
+open class AllegroAuthenticationException(message: String, statusCode: Int? = null) :
+    AllegroException(message, statusCode)
+
+class AllegroSessionExpiredException(message: String, statusCode: Int? = null) :
+    AllegroAuthenticationException(message, statusCode)

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroParser.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroParser.kt
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import dev.itsvic.parceltracker.api.Status
+import org.jsoup.Jsoup
+
+internal object AllegroParser {
+  private val trackingKeys =
+      setOf(
+          "trackingnumber",
+          "trackingid",
+          "waybill",
+          "waybillnumber",
+          "parcelnumber",
+          "shipmentnumber",
+      )
+  private val statusKeys =
+      setOf(
+          "status",
+          "statuslabel",
+          "statustext",
+          "deliverystatus",
+          "parcelstatus",
+          "shipmentstatus",
+      )
+  private val titleKeys = setOf("title", "name", "offername", "productname", "itemname", "label")
+  private val carrierKeys =
+      setOf("carrier", "carriername", "provider", "deliverycompany", "logisticsoperator")
+  private val etaKeys =
+      setOf(
+          "eta",
+          "estimateddelivery",
+          "estimateddeliverydate",
+          "expecteddelivery",
+          "deliverytime",
+          "deliverydate",
+      )
+  private val pickupKeys =
+      setOf("pickuppoint", "deliverypoint", "pointaddress", "locker", "pickupaddress")
+  private val idKeys = setOf("packageid", "parcelid", "shipmentid", "deliveryid", "id")
+  private val displayTextKeys =
+      setOf(
+          "description",
+          "html",
+          "label",
+          "message",
+          "name",
+          "sublabel",
+          "subtitle",
+          "text",
+          "title")
+
+  fun parsePackages(payload: Any?): List<AllegroPackage> {
+    val concrete = parseMboxCards(payload)
+    if (concrete.isNotEmpty()) return mergeDuplicates(concrete)
+
+    val candidates = mutableListOf<Map<*, *>>()
+    walkPairs(payload).forEach { (key, value) ->
+      if (normalizeKey(key) in setOf("packages", "parcels", "shipments", "deliveries")) {
+        (value as? List<*>)?.filterIsInstance<Map<*, *>>()?.let(candidates::addAll)
+      }
+    }
+    walkMappings(payload).forEach { candidate ->
+      val visible = displayStrings(candidate)
+      val type = candidate["type"]?.toString()?.lowercase().orEmpty()
+      val semanticType =
+          listOf("package", "parcel", "shipment", "delivery", "card").any(type::contains)
+      if (visible.any(::looksLikeStatus) && (semanticType || visible.size > 1)) {
+        candidates += candidate
+      }
+    }
+
+    return mergeDuplicates(candidates.distinct().mapIndexedNotNull(::parseCandidate))
+  }
+
+  fun parsePackageDetails(payload: Any?, original: AllegroPackage): AllegroPackage {
+    val visible = visibleComponentStrings(payload)
+    val status = visible.firstOrNull(::looksLikeStatus) ?: original.status
+    return original.copy(
+        status = clean(status),
+        eta = visible.firstOrNull(::looksLikeEta)?.let(::clean) ?: original.eta,
+        pickupPoint =
+            visible.firstOrNull(::looksLikePickupPoint)?.let(::clean) ?: original.pickupPoint,
+        readyForPickup = isReadyForPickup(status),
+        history = parseHistory(visible).ifEmpty { original.history },
+    )
+  }
+
+  fun statusToAppStatus(status: String, readyForPickup: Boolean = false): Status {
+    val value = status.lowercase()
+    return when {
+      readyForPickup || isReadyForPickup(status) -> Status.AwaitingPickup
+      listOf("pickup time", "ostatni dzień", "ostatni dzien").any(value::contains) ->
+          Status.PickupTimeEndingSoon
+      listOf("picked up", "odebrana", "odebrano").any(value::contains) -> Status.PickedUp
+      listOf("delivered", "doręczona", "doreczona", "dostarczona").any(value::contains) ->
+          Status.Delivered
+      listOf(
+              "out for delivery",
+              "w doręczeniu",
+              "w doreczeniu",
+              "przekazana do doręczenia",
+              "przekazana do doreczenia")
+          .any(value::contains) -> Status.OutForDelivery
+      listOf("delayed", "opóźniona", "opozniona").any(value::contains) -> Status.Delayed
+      listOf(
+              "waiting for dispatch",
+              "oczekuje na nadanie",
+              "przygotowana przez nadawcę",
+              "przygotowana przez nadawce")
+          .any(value::contains) -> Status.Preadvice
+      listOf("warehouse", "oddziale", "magazyn").any(value::contains) -> Status.InWarehouse
+      listOf("in transit", "w drodze", "wyruszyła", "wyruszyla", "nadana", "shipped")
+          .any(value::contains) -> Status.InTransit
+      else -> Status.Unknown
+    }
+  }
+
+  private fun parseMboxCards(payload: Any?): List<AllegroPackage> =
+      walkMappings(payload)
+          .mapNotNull { candidate ->
+            val id = candidate["id"] as? String ?: return@mapNotNull null
+            if (id.count { it == ':' } != 1) return@mapNotNull null
+            val (carrierId, tracking) = id.split(':', limit = 2)
+            if (carrierId.isBlank() ||
+                tracking.isBlank() ||
+                candidate["childComponents"] !is List<*>) {
+              return@mapNotNull null
+            }
+
+            val visible = visibleComponentStrings(candidate)
+            val status = visible.firstOrNull(::looksLikeStatus) ?: return@mapNotNull null
+            val eta = visible.firstOrNull(::looksLikeEta).orEmpty()
+            val pickup = visible.firstOrNull(::looksLikePickupPoint).orEmpty()
+            val title =
+                visible.asReversed().firstOrNull {
+                  it != tracking &&
+                      it != pickup &&
+                      !looksLikeStatus(it) &&
+                      !looksLikeSupportingText(it) &&
+                      !looksLikeControlText(it)
+                } ?: tracking
+            AllegroPackage(
+                packageId = tracking,
+                title = clean(title),
+                status = clean(status),
+                carrier = carrierName(carrierId),
+                trackingNumber = tracking,
+                eta = clean(eta),
+                pickupPoint = clean(pickup),
+                readyForPickup = isReadyForPickup(status),
+                carrierId = carrierId,
+            )
+          }
+          .toList()
+
+  private fun parseCandidate(index: Int, candidate: Map<*, *>): AllegroPackage? {
+    var packageId = asText(findFirst(candidate, idKeys))
+    val tracking = asText(findFirst(candidate, trackingKeys))
+    var status = asText(findFirst(candidate, statusKeys))
+    var title = asText(findFirst(candidate, titleKeys))
+    var carrier = asText(findFirst(candidate, carrierKeys))
+    val carrierId = asText(findFirst(candidate, setOf("carrierid")))
+    var eta = asText(findFirst(candidate, etaKeys))
+    val pickupPoint = asText(findFirst(candidate, pickupKeys))
+    val visible = displayStrings(candidate)
+
+    if (status.isBlank()) status = visible.firstOrNull(::looksLikeStatus).orEmpty()
+    if (eta.isBlank()) eta = visible.firstOrNull(::looksLikeEta).orEmpty()
+    if (title.isBlank() || looksLikeStatus(title) || looksLikeControlText(title)) {
+      title =
+          visible
+              .asReversed()
+              .firstOrNull {
+                it != tracking &&
+                    !looksLikeStatus(it) &&
+                    !looksLikeSupportingText(it) &&
+                    !looksLikeControlText(it)
+              }
+              .orEmpty()
+    }
+    if (carrier.isBlank() && carrierId.isNotBlank()) carrier = carrierName(carrierId)
+    if (packageId.isBlank()) packageId = tracking.ifBlank { "package-${index + 1}" }
+    if (title.isBlank()) title = tracking.ifBlank { "Package" }
+    if (status.isBlank() && tracking.isBlank()) return null
+
+    return AllegroPackage(
+        packageId = clean(packageId),
+        title = clean(title),
+        status = clean(status.ifBlank { "Unknown" }),
+        carrier = clean(carrier),
+        trackingNumber = clean(tracking),
+        eta = clean(eta),
+        pickupPoint = clean(pickupPoint),
+        readyForPickup = isReadyForPickup(status),
+        carrierId = clean(carrierId),
+    )
+  }
+
+  private fun mergeDuplicates(packages: List<AllegroPackage>): List<AllegroPackage> {
+    val merged = linkedMapOf<String, AllegroPackage>()
+    packages.forEachIndexed { index, packageItem ->
+      val key =
+          packageItem.trackingNumber
+              .ifBlank { packageItem.packageId.ifBlank { index.toString() } }
+              .lowercase()
+      val previous = merged[key]
+      merged[key] =
+          if (previous == null) packageItem
+          else
+              previous.copy(
+                  title =
+                      listOf(previous.title, packageItem.title)
+                          .filterNot { it == previous.trackingNumber || it == "Package" }
+                          .maxByOrNull(String::length) ?: previous.title,
+                  status =
+                      listOf(previous.status, packageItem.status).firstOrNull {
+                        it.isNotBlank() && it != "Unknown"
+                      } ?: "Unknown",
+                  carrier = previous.carrier.ifBlank { packageItem.carrier },
+                  trackingNumber = previous.trackingNumber.ifBlank { packageItem.trackingNumber },
+                  eta = previous.eta.ifBlank { packageItem.eta },
+                  pickupPoint = previous.pickupPoint.ifBlank { packageItem.pickupPoint },
+                  readyForPickup = previous.readyForPickup || packageItem.readyForPickup,
+                  carrierId = previous.carrierId.ifBlank { packageItem.carrierId },
+              )
+    }
+    return merged.values.toList()
+  }
+
+  private fun parseHistory(strings: List<String>): List<AllegroTrackingEvent> {
+    val result = mutableListOf<AllegroTrackingEvent>()
+    var previous = ""
+    strings.forEach { text ->
+      if (looksLikeTimestamp(text) && previous.isNotBlank() && looksLikeHistoryStatus(previous)) {
+        AllegroTrackingEvent(previous, text).let { if (it !in result) result += it }
+      }
+      if (text.isNotBlank()) previous = text
+    }
+    return result
+  }
+
+  private fun visibleComponentStrings(value: Any?): List<String> {
+    val result = mutableListOf<String>()
+    fun visit(component: Any?) {
+      val map = component as? Map<*, *> ?: return
+      (map["text"] as? String)?.let(::clean)?.takeIf(String::isNotBlank)?.let(result::add)
+      listOf("childComponents", "variants", "labelParts").forEach { key ->
+        (map[key] as? List<*>)?.forEach(::visit)
+      }
+      listOf("content", "component").forEach { visit(map[it]) }
+    }
+    when (value) {
+      is Map<*, *> -> visit(value)
+      is List<*> -> value.forEach(::visit)
+    }
+    return result.distinct()
+  }
+
+  private fun displayStrings(value: Any?): List<String> =
+      walkPairs(value)
+          .filter { (key, child) -> normalizeKey(key) in displayTextKeys && child is String }
+          .map { clean(it.second as String) }
+          .filter(String::isNotBlank)
+          .distinct()
+          .toList()
+
+  private fun findFirst(value: Any?, keys: Set<String>): Any? =
+      walkPairs(value)
+          .firstOrNull { (key, child) ->
+            normalizeKey(key) in keys &&
+                child !in listOf(null, "", emptyList<Any>(), emptyMap<Any, Any>())
+          }
+          ?.second
+
+  private fun walkPairs(value: Any?): Sequence<Pair<String, Any?>> = sequence {
+    when (value) {
+      is Map<*, *> ->
+          value.forEach { (key, child) ->
+            yield(key.toString() to child)
+            yieldAll(walkPairs(child))
+          }
+      is List<*> -> value.forEach { yieldAll(walkPairs(it)) }
+    }
+  }
+
+  private fun walkMappings(value: Any?): Sequence<Map<*, *>> = sequence {
+    when (value) {
+      is Map<*, *> -> {
+        yield(value)
+        value.values.forEach { yieldAll(walkMappings(it)) }
+      }
+      is List<*> -> value.forEach { yieldAll(walkMappings(it)) }
+    }
+  }
+
+  private fun asText(value: Any?): String =
+      when (value) {
+        null -> ""
+        is String -> value
+        is Number -> value.toString()
+        is Map<*, *> ->
+            listOf("text", "label", "name", "title", "value", "formatted")
+                .firstNotNullOfOrNull { key ->
+                  value[key]?.let(::asText)?.takeIf(String::isNotBlank)
+                }
+                .orEmpty()
+        is List<*> -> value.map(::asText).filter(String::isNotBlank).joinToString(" - ")
+        else -> value.toString()
+      }
+
+  private fun clean(value: String): String =
+      Jsoup.parseBodyFragment(value)
+          .text()
+          .replace('\u00a0', ' ')
+          .replace(Regex("\\s+"), " ")
+          .trim()
+
+  private fun normalizeKey(value: String): String =
+      value.lowercase().replace(Regex("[^a-z0-9]"), "")
+
+  private fun carrierName(carrierId: String): String =
+      when (carrierId.lowercase()) {
+        "inpost" -> "InPost"
+        "allegro" -> "Allegro One"
+        else -> carrierId.replace('_', ' ').lowercase().replaceFirstChar(Char::uppercase)
+      }
+
+  private fun looksLikeEta(value: String): Boolean =
+      listOf("przewidywana dostawa", "estimated delivery", "delivery by")
+          .any(value.lowercase()::contains)
+
+  private fun looksLikePickupPoint(value: String): Boolean =
+      listOf(
+              "punkt wybrany przy zakupie",
+              "allegro one box",
+              "paczkomat",
+              "pickup point",
+              "parcel locker")
+          .any(value.lowercase()::contains)
+
+  private fun looksLikeStatus(value: String): Boolean =
+      listOf(
+              "ready for pickup",
+              "gotowa do odbioru",
+              "gotowe do odbioru",
+              "odbierz przesyłkę",
+              "w drodze",
+              "wyruszyła do punktu",
+              "wyruszyla do punktu",
+              "wyruszyła w drogę",
+              "wyruszyla w droge",
+              "in transit",
+              "out for delivery",
+              "dzisiaj w punkcie",
+              "przekazana do doręczenia",
+              "przekazana do doreczenia",
+              "w doręczeniu",
+              "nadana",
+              "shipped",
+              "oczekuje na nadanie",
+              "waiting for dispatch",
+              "delivered",
+              "doręczona",
+              "doreczona",
+              "dostarczona",
+              "opóźniona",
+              "opozniona",
+              "delayed",
+          )
+          .any(value.lowercase()::contains)
+
+  private fun isReadyForPickup(value: String): Boolean =
+      listOf("ready for pickup", "gotowa do odbioru", "gotowe do odbioru", "odbierz")
+          .any(value.lowercase()::contains)
+
+  private fun looksLikeTimestamp(value: String): Boolean =
+      Regex("\\b\\d{1,2}\\s+[\\p{L}.]+\\s+\\d{4},\\s*\\d{1,2}:\\d{2}\\b", RegexOption.IGNORE_CASE)
+          .containsMatchIn(value) ||
+          Regex("\\b\\d{4}-\\d{2}-\\d{2}[ T]\\d{1,2}:\\d{2}\\b").containsMatchIn(value)
+
+  private fun looksLikeHistoryStatus(value: String): Boolean {
+    if (looksLikeTimestamp(value) ||
+        looksLikeEta(value) ||
+        looksLikePickupPoint(value) ||
+        looksLikeControlText(value))
+        return false
+    return normalizeKey(value) !in
+        setOf("historiaprzesylki", "shipmenthistory", "twojzakup", "yourpurchase")
+  }
+
+  private fun looksLikeSupportingText(value: String): Boolean =
+      looksLikeEta(value) ||
+          listOf(
+                  "pokaż na mapie",
+                  "pokaz na mapie",
+                  "show on map",
+                  "szczegóły dostawy",
+                  "szczegoly dostawy",
+                  "delivery details",
+                  "coś poszło nie tak",
+                  "something went wrong")
+              .any(value.lowercase()::contains)
+
+  private fun looksLikeControlText(value: String): Boolean =
+      normalizeKey(value) in
+          setOf(
+              "archivepackage",
+              "deletepackage",
+              "deliverydetails",
+              "dodatkoweopcje",
+              "moreoptions",
+              "removepackage",
+              "sharepackage",
+              "szczegolydostawy",
+              "udostepnijdopki",
+              "udostepnijdoapki",
+              "udostepnijprzesylke",
+          )
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroParser.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroParser.kt
@@ -38,6 +38,11 @@ internal object AllegroParser {
   private val pickupKeys =
       setOf("pickuppoint", "deliverypoint", "pointaddress", "locker", "pickupaddress")
   private val idKeys = setOf("packageid", "parcelid", "shipmentid", "deliveryid", "id")
+  private val pickupCodePattern = Regex("Kod odbioru:\\s*([\\d ]+)")
+  private val pickupPhonePattern = Regex("Nr odbiorcy:\\s*([\\d ]+)")
+  private val multiboxIndexPattern =
+      Regex("\\d+\\s+z\\s+\\d+\\s+przesyłek?", RegexOption.IGNORE_CASE)
+  private val boxIdPattern = Regex("[?&]boxId=([A-Z0-9_]+)")
   private val displayTextKeys =
       setOf(
           "description",
@@ -76,12 +81,19 @@ internal object AllegroParser {
   fun parsePackageDetails(payload: Any?, original: AllegroPackage): AllegroPackage {
     val visible = visibleComponentStrings(payload)
     val status = visible.firstOrNull(::looksLikeStatus) ?: original.status
+    val (pickupCode, pickupPhoneNumber) = extractPickupCredentials(payload)
     return original.copy(
         status = clean(status),
         eta = visible.firstOrNull(::looksLikeEta)?.let(::clean) ?: original.eta,
         pickupPoint =
             visible.firstOrNull(::looksLikePickupPoint)?.let(::clean) ?: original.pickupPoint,
         readyForPickup = isReadyForPickup(status),
+        pickupCode = pickupCode.ifBlank { original.pickupCode },
+        pickupPhoneNumber = pickupPhoneNumber.ifBlank { original.pickupPhoneNumber },
+        multiboxGroupId = extractMultiboxGroupId(payload).ifBlank { original.multiboxGroupId },
+        multiboxIndex =
+            visible.firstOrNull { multiboxIndexPattern.containsMatchIn(it) }?.let(::clean)
+                ?: original.multiboxIndex,
         history = parseHistory(visible).ifEmpty { original.history },
     )
   }
@@ -110,7 +122,14 @@ internal object AllegroParser {
               "przygotowana przez nadawce")
           .any(value::contains) -> Status.Preadvice
       listOf("warehouse", "oddziale", "magazyn").any(value::contains) -> Status.InWarehouse
-      listOf("in transit", "w drodze", "wyruszyła", "wyruszyla", "nadana", "shipped")
+      listOf(
+              "in transit",
+              "w drodze",
+              "wyruszyła",
+              "wyruszyla",
+              "nadana",
+              "shipped",
+              "dzisiaj w punkcie")
           .any(value::contains) -> Status.InTransit
       else -> Status.Unknown
     }
@@ -132,6 +151,7 @@ internal object AllegroParser {
             val status = visible.firstOrNull(::looksLikeStatus) ?: return@mapNotNull null
             val eta = visible.firstOrNull(::looksLikeEta).orEmpty()
             val pickup = visible.firstOrNull(::looksLikePickupPoint).orEmpty()
+            val (pickupCode, pickupPhoneNumber) = extractPickupCredentials(candidate)
             val title =
                 visible.asReversed().firstOrNull {
                   it != tracking &&
@@ -150,6 +170,14 @@ internal object AllegroParser {
                 pickupPoint = clean(pickup),
                 readyForPickup = isReadyForPickup(status),
                 carrierId = carrierId,
+                pickupCode = pickupCode,
+                pickupPhoneNumber = pickupPhoneNumber,
+                multiboxGroupId = extractMultiboxGroupId(candidate),
+                multiboxIndex =
+                    visible
+                        .firstOrNull { multiboxIndexPattern.containsMatchIn(it) }
+                        ?.let(::clean)
+                        .orEmpty(),
             )
           }
           .toList()
@@ -183,6 +211,7 @@ internal object AllegroParser {
     if (packageId.isBlank()) packageId = tracking.ifBlank { "package-${index + 1}" }
     if (title.isBlank()) title = tracking.ifBlank { "Package" }
     if (status.isBlank() && tracking.isBlank()) return null
+    val (pickupCode, pickupPhoneNumber) = extractPickupCredentials(candidate)
 
     return AllegroPackage(
         packageId = clean(packageId),
@@ -194,6 +223,14 @@ internal object AllegroParser {
         pickupPoint = clean(pickupPoint),
         readyForPickup = isReadyForPickup(status),
         carrierId = clean(carrierId),
+        pickupCode = pickupCode,
+        pickupPhoneNumber = pickupPhoneNumber,
+        multiboxGroupId = extractMultiboxGroupId(candidate),
+        multiboxIndex =
+            visible
+                .firstOrNull { multiboxIndexPattern.containsMatchIn(it) }
+                ?.let(::clean)
+                .orEmpty(),
     )
   }
 
@@ -223,6 +260,12 @@ internal object AllegroParser {
                   pickupPoint = previous.pickupPoint.ifBlank { packageItem.pickupPoint },
                   readyForPickup = previous.readyForPickup || packageItem.readyForPickup,
                   carrierId = previous.carrierId.ifBlank { packageItem.carrierId },
+                  pickupCode = previous.pickupCode.ifBlank { packageItem.pickupCode },
+                  pickupPhoneNumber =
+                      previous.pickupPhoneNumber.ifBlank { packageItem.pickupPhoneNumber },
+                  multiboxGroupId =
+                      previous.multiboxGroupId.ifBlank { packageItem.multiboxGroupId },
+                  multiboxIndex = previous.multiboxIndex.ifBlank { packageItem.multiboxIndex },
               )
     }
     return merged.values.toList()
@@ -255,6 +298,34 @@ internal object AllegroParser {
       is List<*> -> value.forEach(::visit)
     }
     return result.distinct()
+  }
+
+  private fun extractPickupCredentials(value: Any?): Pair<String, String> {
+    var code = ""
+    var phone = ""
+    walkPairs(value).forEach { (_, child) ->
+      if (child is String) {
+        if (code.isBlank()) {
+          code = pickupCodePattern.find(child)?.groupValues?.get(1)?.trim().orEmpty()
+        }
+        if (phone.isBlank()) {
+          phone = pickupPhonePattern.find(child)?.groupValues?.get(1)?.trim().orEmpty()
+        }
+        if (code.isNotBlank() && phone.isNotBlank()) return code to phone
+      }
+    }
+    return code to phone
+  }
+
+  private fun extractMultiboxGroupId(value: Any?): String {
+    walkPairs(value).forEach { (_, child) ->
+      if (child is String) {
+        boxIdPattern.find(child)?.groupValues?.get(1)?.let {
+          return it
+        }
+      }
+    }
+    return ""
   }
 
   private fun displayStrings(value: Any?): List<String> =
@@ -345,6 +416,7 @@ internal object AllegroParser {
               "gotowa do odbioru",
               "gotowe do odbioru",
               "odbierz przesyłkę",
+              "odbierz przesyłki",
               "w drodze",
               "wyruszyła do punktu",
               "wyruszyla do punktu",

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroRepository.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroRepository.kt
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import android.content.Context
+import androidx.room.withTransaction
+import dev.itsvic.parceltracker.ParcelApplication
+import dev.itsvic.parceltracker.R
+import dev.itsvic.parceltracker.api.Parcel as ApiParcel
+import dev.itsvic.parceltracker.api.ParcelHistoryItem as ApiHistoryItem
+import dev.itsvic.parceltracker.api.Service
+import dev.itsvic.parceltracker.db.AllegroPackageLink
+import dev.itsvic.parceltracker.db.Parcel
+import dev.itsvic.parceltracker.db.ParcelStatus
+import dev.itsvic.parceltracker.sendNotification
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class AllegroRepository(context: Context) {
+  private val appContext = context.applicationContext
+  private val store = AllegroSessionStore(appContext)
+  private val db = ParcelApplication.db
+
+  fun session(): AllegroSession? = store.load()
+
+  suspend fun login(username: String, password: String): AllegroSession =
+      accountMutex.withLock {
+        val previous = store.load()
+        val session = AllegroClient().login(username.trim(), password)
+        if (previous != null &&
+            allegroAccountKey(previous.username) != allegroAccountKey(session.username)) {
+          db.allegroPackageLinkDao().revokePickupCodes(allegroAccountKey(previous.username))
+        }
+        store.save(session)
+        session
+      }
+
+  suspend fun logout() =
+      accountMutex.withLock {
+        val saved = store.load()
+        try {
+          saved?.let {
+            db.allegroPackageLinkDao().revokePickupCodes(allegroAccountKey(it.username))
+          }
+        } finally {
+          store.clear()
+        }
+      }
+
+  suspend fun sync(notifyChanges: Boolean = false): Int =
+      accountMutex.withLock {
+        val saved = store.load() ?: return 0
+        val accountKey = allegroAccountKey(saved.username)
+        val client =
+            AllegroClient(saved, debugInterceptor = createAllegroDebugInterceptor(appContext))
+        val packages =
+            try {
+              client.fetchDashboard()
+            } catch (error: AllegroSessionExpiredException) {
+              clearSession(accountKey)
+              throw error
+            }
+        client.session?.let(store::save)
+        val now = Instant.now()
+        val notifications = mutableListOf<StatusChange>()
+        var syncedCount = 0
+
+        db.withTransaction {
+          packages.forEach { remote ->
+            val waybill = remote.trackingNumber.ifBlank { remote.packageId }
+            if (waybill.isBlank()) return@forEach
+            val oldLink =
+                db.allegroPackageLinkDao().findRemote(accountKey, remote.packageId, waybill)
+            val localParcel =
+                if (oldLink == null) {
+                  val id =
+                      db.parcelDao()
+                          .insert(
+                              Parcel(
+                                  humanName = remote.title.ifBlank { waybill },
+                                  parcelId = waybill,
+                                  postalCode = null,
+                                  service = Service.ALLEGRO_ACCOUNT,
+                              ))
+                          .toInt()
+                  db.parcelDao().getByIdAsync(id)!!
+                } else {
+                  val existing = db.parcelDao().getByIdAsync(oldLink.parcelId) ?: return@forEach
+                  if (existing.parcelId != waybill || existing.service != Service.ALLEGRO_ACCOUNT) {
+                    existing
+                        .copy(
+                            parcelId = waybill,
+                            postalCode = null,
+                            service = Service.ALLEGRO_ACCOUNT,
+                        )
+                        .also { db.parcelDao().update(it) }
+                  } else {
+                    existing
+                  }
+                }
+            val statusChanged =
+                oldLink != null &&
+                    (oldLink.statusText != remote.status ||
+                        oldLink.readyForPickup != remote.readyForPickup)
+            val changedAt = if (oldLink == null || statusChanged) now else oldLink.statusChangedAt
+            val link =
+                AllegroPackageLink(
+                    parcelId = localParcel.id,
+                    accountKey = accountKey,
+                    remotePackageId = remote.packageId,
+                    carrierId = remote.carrierId.ifBlank { carrierId(remote.carrier) },
+                    carrierName = remote.carrier,
+                    waybill = waybill,
+                    statusText = remote.status,
+                    readyForPickup = remote.readyForPickup,
+                    statusChangedAt = changedAt,
+                    lastSeenAt = now,
+                )
+            db.allegroPackageLinkDao().upsert(link)
+            val appStatus = AllegroParser.statusToAppStatus(remote.status, remote.readyForPickup)
+            db.parcelStatusDao().upsert(ParcelStatus(localParcel.id, appStatus, changedAt))
+            if (notifyChanges && statusChanged && !localParcel.isArchived) {
+              notifications += StatusChange(localParcel, appStatus, remote.status)
+            }
+            syncedCount++
+          }
+          db.allegroPackageLinkDao().revokeUnseenPickupCodes(accountKey, now)
+        }
+
+        notifications.forEach { change ->
+          appContext.sendNotification(
+              change.parcel,
+              change.status,
+              ApiHistoryItem(change.description, LocalDateTime.now(), ""),
+          )
+        }
+        syncedCount
+      }
+
+  suspend fun fetchParcel(trackingNumber: String): ApiParcel =
+      accountMutex.withLock {
+        val saved = store.load()
+        val link =
+            saved?.let {
+              db.allegroPackageLinkDao()
+                  .findByWaybill(allegroAccountKey(it.username), trackingNumber)
+            } ?: return cachedParcel(trackingNumber)
+        val client =
+            AllegroClient(saved, debugInterceptor = createAllegroDebugInterceptor(appContext))
+        val original = link.toRemotePackage()
+        val details =
+            try {
+              client.fetchPackageDetails(original)
+            } catch (error: AllegroSessionExpiredException) {
+              clearSession(allegroAccountKey(saved.username))
+              return link.toApiParcel(original)
+            }
+        client.session?.let(store::save)
+        return link.toApiParcel(details)
+      }
+
+  suspend fun fetchPickupDetails(link: AllegroPackageLink): AllegroPickupDetails =
+      accountMutex.withLock {
+        val saved =
+            store.load()
+                ?: throw AllegroSessionExpiredException("Log in to your Allegro account first.")
+        if (allegroAccountKey(saved.username) != link.accountKey) {
+          throw AllegroSessionExpiredException("Log in to the Allegro account for this package.")
+        }
+        val client =
+            AllegroClient(saved, debugInterceptor = createAllegroDebugInterceptor(appContext))
+        return try {
+          client.fetchPickupDetails(link.carrierId, link.waybill).also {
+            client.session?.let(store::save)
+          }
+        } catch (error: AllegroSessionExpiredException) {
+          clearSession(link.accountKey)
+          throw error
+        }
+      }
+
+  private suspend fun clearSession(accountKey: String) {
+    try {
+      db.allegroPackageLinkDao().revokePickupCodes(accountKey)
+    } finally {
+      store.clear()
+    }
+  }
+
+  private suspend fun cachedParcel(trackingNumber: String): ApiParcel {
+    val parcel =
+        db.parcelDao().getAllNonArchivedWithStatusAsync().firstOrNull {
+          it.parcel.parcelId == trackingNumber && it.parcel.service == Service.ALLEGRO_ACCOUNT
+        }
+    val status = parcel?.status
+    val time =
+        status?.lastChange?.atZone(ZoneId.systemDefault())?.toLocalDateTime() ?: LocalDateTime.now()
+    return ApiParcel(
+        trackingNumber,
+        listOf(ApiHistoryItem("Saved Allegro status", time, "")),
+        status?.status ?: dev.itsvic.parceltracker.api.Status.Unknown,
+    )
+  }
+
+  private fun AllegroPackageLink.toRemotePackage() =
+      AllegroPackage(
+          packageId = remotePackageId,
+          title = waybill,
+          status = statusText,
+          carrier = carrierName,
+          trackingNumber = waybill,
+          readyForPickup = readyForPickup,
+          carrierId = carrierId,
+      )
+
+  private fun AllegroPackageLink.toApiParcel(remote: AllegroPackage): ApiParcel {
+    val history =
+        remote.history
+            .map {
+              ApiHistoryItem(
+                  description = it.status,
+                  time = parseTimestamp(it.timestamp) ?: statusChangedAt.atLocalTime(),
+                  location = "",
+              )
+            }
+            .ifEmpty { listOf(ApiHistoryItem(remote.status, statusChangedAt.atLocalTime(), "")) }
+    val properties = buildMap {
+      if (remote.eta.isNotBlank()) put(R.string.property_eta, remote.eta)
+      if (remote.pickupPoint.isNotBlank()) {
+        put(R.string.property_pickup_point, remote.pickupPoint)
+      }
+    }
+    return ApiParcel(
+        id = waybill,
+        history = history,
+        currentStatus = AllegroParser.statusToAppStatus(remote.status, remote.readyForPickup),
+        properties = properties,
+    )
+  }
+
+  private fun parseTimestamp(value: String): LocalDateTime? {
+    if (value.isBlank()) return null
+    listOf(
+            DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm", Locale.forLanguageTag("pl-PL")),
+            DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"),
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+        )
+        .forEach { formatter ->
+          try {
+            return LocalDateTime.parse(value, formatter)
+          } catch (_: DateTimeParseException) {}
+        }
+    return null
+  }
+
+  private fun Instant.atLocalTime(): LocalDateTime =
+      atZone(ZoneId.systemDefault()).toLocalDateTime()
+
+  private fun carrierId(carrier: String): String =
+      when (carrier.lowercase()) {
+        "allegro",
+        "allegro one",
+        "allegro one box" -> "ALLEGRO"
+        "inpost" -> "INPOST"
+        else -> carrier.uppercase().replace(' ', '_')
+      }
+
+  private data class StatusChange(
+      val parcel: Parcel,
+      val status: dev.itsvic.parceltracker.api.Status,
+      val description: String,
+  )
+
+  companion object {
+    private val accountMutex = Mutex()
+  }
+}
+
+internal fun allegroAccountKey(username: String): String {
+  val digest =
+      MessageDigest.getInstance("SHA-256")
+          .digest(username.trim().lowercase(Locale.ROOT).toByteArray(Charsets.UTF_8))
+  val alphabet = "0123456789abcdef"
+  return buildString(digest.size * 2) {
+    digest.forEach { byte ->
+      val value = byte.toInt() and 0xff
+      append(alphabet[value ushr 4])
+      append(alphabet[value and 0x0f])
+    }
+  }
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroRepository.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroRepository.kt
@@ -13,6 +13,7 @@ import dev.itsvic.parceltracker.db.Parcel
 import dev.itsvic.parceltracker.db.ParcelStatus
 import dev.itsvic.parceltracker.sendNotification
 import java.security.MessageDigest
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -65,11 +66,27 @@ class AllegroRepository(context: Context) {
             } catch (error: AllegroSessionExpiredException) {
               clearSession(accountKey)
               throw error
+            } catch (error: AllegroException) {
+              client.session?.let(store::save)
+              throw error
             }
         client.session?.let(store::save)
         val now = Instant.now()
         val notifications = mutableListOf<StatusChange>()
         var syncedCount = 0
+        val currentPackageIds = packages.mapTo(mutableSetOf()) { it.packageId }
+        val staleRefreshes =
+            db.allegroPackageLinkDao()
+                .getAllForAccount(accountKey)
+                .filter {
+                  it.remotePackageId !in currentPackageIds &&
+                      it.lastSeenAt.isAfter(now.minus(Duration.ofHours(24)))
+                }
+                .take(3)
+                .map { link ->
+                  link to
+                      runCatching { client.fetchPackageDetails(link.toRemotePackage()) }.getOrNull()
+                }
 
         db.withTransaction {
           packages.forEach { remote ->
@@ -119,6 +136,10 @@ class AllegroRepository(context: Context) {
                     waybill = waybill,
                     statusText = remote.status,
                     readyForPickup = remote.readyForPickup,
+                    pickupCode = remote.pickupCode,
+                    pickupPhoneNumber = remote.pickupPhoneNumber,
+                    multiboxGroupId = remote.multiboxGroupId,
+                    multiboxIndex = remote.multiboxIndex,
                     statusChangedAt = changedAt,
                     lastSeenAt = now,
                 )
@@ -129,6 +150,32 @@ class AllegroRepository(context: Context) {
               notifications += StatusChange(localParcel, appStatus, remote.status)
             }
             syncedCount++
+          }
+          staleRefreshes.forEach { (link, details) ->
+            if (details != null) {
+              val statusChanged =
+                  link.statusText != details.status || link.readyForPickup != details.readyForPickup
+              val changedAt = if (statusChanged) now else link.statusChangedAt
+              db.allegroPackageLinkDao()
+                  .upsert(
+                      link.copy(
+                          statusText = details.status,
+                          readyForPickup = details.readyForPickup,
+                          pickupCode = details.pickupCode,
+                          pickupPhoneNumber = details.pickupPhoneNumber,
+                          multiboxGroupId = details.multiboxGroupId,
+                          multiboxIndex = details.multiboxIndex,
+                          statusChangedAt = changedAt,
+                          lastSeenAt = now,
+                      ))
+              db.parcelStatusDao()
+                  .upsert(
+                      ParcelStatus(
+                          link.parcelId,
+                          AllegroParser.statusToAppStatus(details.status, details.readyForPickup),
+                          changedAt,
+                      ))
+            }
           }
           db.allegroPackageLinkDao().revokeUnseenPickupCodes(accountKey, now)
         }
@@ -160,8 +207,36 @@ class AllegroRepository(context: Context) {
             } catch (error: AllegroSessionExpiredException) {
               clearSession(allegroAccountKey(saved.username))
               return link.toApiParcel(original)
+            } catch (error: AllegroException) {
+              client.session?.let(store::save)
+              throw error
             }
         client.session?.let(store::save)
+        db.withTransaction {
+          val now = Instant.now()
+          val statusChanged =
+              link.statusText != details.status || link.readyForPickup != details.readyForPickup
+          val changedAt = if (statusChanged) now else link.statusChangedAt
+          db.allegroPackageLinkDao()
+              .upsert(
+                  link.copy(
+                      statusText = details.status,
+                      readyForPickup = details.readyForPickup,
+                      pickupCode = details.pickupCode,
+                      pickupPhoneNumber = details.pickupPhoneNumber,
+                      multiboxGroupId = details.multiboxGroupId,
+                      multiboxIndex = details.multiboxIndex,
+                      statusChangedAt = changedAt,
+                      lastSeenAt = now,
+                  ))
+          db.parcelStatusDao()
+              .upsert(
+                  ParcelStatus(
+                      link.parcelId,
+                      AllegroParser.statusToAppStatus(details.status, details.readyForPickup),
+                      changedAt,
+                  ))
+        }
         return link.toApiParcel(details)
       }
 
@@ -175,13 +250,25 @@ class AllegroRepository(context: Context) {
         }
         val client =
             AllegroClient(saved, debugInterceptor = createAllegroDebugInterceptor(appContext))
-        return try {
+        try {
           client.fetchPickupDetails(link.carrierId, link.waybill).also {
             client.session?.let(store::save)
           }
         } catch (error: AllegroSessionExpiredException) {
           clearSession(link.accountKey)
           throw error
+        } catch (error: AllegroException) {
+          client.session?.let(store::save)
+          if (link.pickupCode.isNotBlank() || link.pickupPhoneNumber.isNotBlank()) {
+            AllegroPickupDetails(
+                waybill = link.waybill,
+                carrierId = link.carrierId,
+                code = link.pickupCode,
+                phoneNumber = link.pickupPhoneNumber,
+            )
+          } else {
+            throw error
+          }
         }
       }
 
@@ -217,6 +304,10 @@ class AllegroRepository(context: Context) {
           trackingNumber = waybill,
           readyForPickup = readyForPickup,
           carrierId = carrierId,
+          pickupCode = pickupCode,
+          pickupPhoneNumber = pickupPhoneNumber,
+          multiboxGroupId = multiboxGroupId,
+          multiboxIndex = multiboxIndex,
       )
 
   private fun AllegroPackageLink.toApiParcel(remote: AllegroPackage): ApiParcel {
@@ -234,6 +325,9 @@ class AllegroRepository(context: Context) {
       if (remote.eta.isNotBlank()) put(R.string.property_eta, remote.eta)
       if (remote.pickupPoint.isNotBlank()) {
         put(R.string.property_pickup_point, remote.pickupPoint)
+      }
+      if (remote.multiboxIndex.isNotBlank()) {
+        put(R.string.property_multibox, remote.multiboxIndex)
       }
     }
     return ApiParcel(

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroSessionStore.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroSessionStore.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import com.squareup.moshi.Moshi
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class AllegroSessionStore(context: Context) {
+  private val appContext = context.applicationContext
+  private val preferences = appContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+  private val adapter = Moshi.Builder().build().adapter(AllegroSession::class.java)
+
+  @Synchronized
+  fun load(): AllegroSession? {
+    val encrypted = preferences.getString(SESSION_KEY, null) ?: return null
+    return try {
+      val parts = encrypted.split('.', limit = 2)
+      require(parts.size == 2)
+      val cipher = Cipher.getInstance(TRANSFORMATION)
+      cipher.init(
+          Cipher.DECRYPT_MODE,
+          getOrCreateKey(),
+          GCMParameterSpec(128, Base64.decode(parts[0], Base64.NO_WRAP)),
+      )
+      cipher.updateAAD(appContext.packageName.toByteArray())
+      val json = String(cipher.doFinal(Base64.decode(parts[1], Base64.NO_WRAP)), Charsets.UTF_8)
+      adapter.fromJson(json)
+    } catch (_: Exception) {
+      clear()
+      null
+    }
+  }
+
+  @Synchronized
+  fun save(session: AllegroSession) {
+    val cipher = Cipher.getInstance(TRANSFORMATION)
+    cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+    cipher.updateAAD(appContext.packageName.toByteArray())
+    val ciphertext = cipher.doFinal(adapter.toJson(session).toByteArray(Charsets.UTF_8))
+    val value =
+        "${Base64.encodeToString(cipher.iv, Base64.NO_WRAP)}.${Base64.encodeToString(ciphertext, Base64.NO_WRAP)}"
+    preferences.edit().putString(SESSION_KEY, value).apply()
+  }
+
+  @Synchronized fun clear() = preferences.edit().clear().apply()
+
+  private fun getOrCreateKey(): SecretKey {
+    val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER).apply { load(null) }
+    (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let {
+      return it
+    }
+
+    return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER).run {
+      init(
+          KeyGenParameterSpec.Builder(
+                  KEY_ALIAS,
+                  KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+              )
+              .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+              .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+              .build())
+      generateKey()
+    }
+  }
+
+  companion object {
+    const val PREFERENCES_NAME = "allegro_session"
+    private const val SESSION_KEY = "encrypted_session"
+    private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+    private const val KEY_ALIAS = "deliveries_allegro_session"
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+  }
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroSessionStore.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/allegro/AllegroSessionStore.kt
@@ -33,7 +33,6 @@ class AllegroSessionStore(context: Context) {
       val json = String(cipher.doFinal(Base64.decode(parts[1], Base64.NO_WRAP)), Charsets.UTF_8)
       adapter.fromJson(json)
     } catch (_: Exception) {
-      clear()
       null
     }
   }
@@ -46,10 +45,15 @@ class AllegroSessionStore(context: Context) {
     val ciphertext = cipher.doFinal(adapter.toJson(session).toByteArray(Charsets.UTF_8))
     val value =
         "${Base64.encodeToString(cipher.iv, Base64.NO_WRAP)}.${Base64.encodeToString(ciphertext, Base64.NO_WRAP)}"
-    preferences.edit().putString(SESSION_KEY, value).apply()
+    check(preferences.edit().putString(SESSION_KEY, value).commit()) {
+      "Could not persist the Allegro session."
+    }
   }
 
-  @Synchronized fun clear() = preferences.edit().clear().apply()
+  @Synchronized
+  fun clear() {
+    check(preferences.edit().clear().commit()) { "Could not clear the Allegro session." }
+  }
 
   private fun getOrCreateKey(): SecretKey {
     val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER).apply { load(null) }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AllegroAccountDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AllegroAccountDeliveryService.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.api
+
+import android.content.Context
+import dev.itsvic.parceltracker.R
+import dev.itsvic.parceltracker.allegro.AllegroRepository
+
+object AllegroAccountDeliveryService : DeliveryService {
+  override val nameResource: Int = R.string.service_allegro_account
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
+
+  override suspend fun getParcel(
+      context: Context,
+      trackingId: String,
+      postalCode: String?,
+  ): Parcel = AllegroRepository(context).fetchParcel(trackingId)
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -51,6 +51,7 @@ enum class Service {
   UKRPOSHTA,
   POSTNORD,
   ALLEGRO_ONEBOX,
+  ALLEGRO_ACCOUNT,
   INPOST,
   INPOST_IT,
   ORLEN_PACZKA,
@@ -63,7 +64,9 @@ enum class Service {
 val serviceOptions =
     Service.entries
         .filter {
-          return@filter it != Service.UNDEFINED && it != Service.EXAMPLE
+          return@filter it != Service.UNDEFINED &&
+              it != Service.EXAMPLE &&
+              it != Service.ALLEGRO_ACCOUNT
         }
         .toList()
 
@@ -98,6 +101,7 @@ fun getDeliveryService(service: Service): DeliveryService? {
     Service.UKRPOSHTA -> UkrposhtaDeliveryService
     Service.POSTNORD -> PostNordDeliveryService
     Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
+    Service.ALLEGRO_ACCOUNT -> AllegroAccountDeliveryService
     Service.INPOST -> InPostDeliveryService
     Service.INPOST_IT -> InPostItalyDeliveryService
     Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService

--- a/app/src/main/java/dev/itsvic/parceltracker/db/AllegroPackageLink.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/AllegroPackageLink.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.db
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Upsert
+import java.time.Instant
+import kotlinx.coroutines.flow.Flow
+
+@Entity(
+    foreignKeys =
+        [
+            ForeignKey(
+                entity = Parcel::class,
+                parentColumns = ["id"],
+                childColumns = ["parcelId"],
+                onDelete = ForeignKey.CASCADE,
+            )],
+    indices =
+        [
+            Index(value = ["accountKey", "remotePackageId"], unique = true),
+            Index(value = ["accountKey", "waybill"]),
+        ],
+)
+data class AllegroPackageLink(
+    @PrimaryKey val parcelId: Int,
+    val accountKey: String,
+    val remotePackageId: String,
+    val carrierId: String,
+    val carrierName: String,
+    val waybill: String,
+    val statusText: String,
+    val readyForPickup: Boolean,
+    val statusChangedAt: Instant,
+    val lastSeenAt: Instant,
+)
+
+@Dao
+interface AllegroPackageLinkDao {
+  @Query("SELECT * FROM AllegroPackageLink WHERE parcelId = :parcelId")
+  fun observeByParcelId(parcelId: Int): Flow<AllegroPackageLink?>
+
+  @Query("SELECT * FROM AllegroPackageLink WHERE parcelId = :parcelId")
+  suspend fun getByParcelId(parcelId: Int): AllegroPackageLink?
+
+  @Query(
+      """SELECT * FROM AllegroPackageLink
+         WHERE accountKey = :accountKey
+           AND (remotePackageId = :remotePackageId OR waybill = :waybill)
+         LIMIT 1""")
+  suspend fun findRemote(
+      accountKey: String,
+      remotePackageId: String,
+      waybill: String,
+  ): AllegroPackageLink?
+
+  @Query(
+      """SELECT * FROM AllegroPackageLink
+         WHERE accountKey = :accountKey AND waybill = :waybill
+         LIMIT 1""")
+  suspend fun findByWaybill(accountKey: String, waybill: String): AllegroPackageLink?
+
+  @Query(
+      """UPDATE AllegroPackageLink SET readyForPickup = 0
+         WHERE accountKey = :accountKey AND lastSeenAt < :syncStarted""")
+  suspend fun revokeUnseenPickupCodes(accountKey: String, syncStarted: Instant)
+
+  @Query("UPDATE AllegroPackageLink SET readyForPickup = 0 WHERE accountKey = :accountKey")
+  suspend fun revokePickupCodes(accountKey: String)
+
+  @Upsert suspend fun upsert(link: AllegroPackageLink)
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/db/AllegroPackageLink.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/AllegroPackageLink.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package dev.itsvic.parceltracker.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Entity
 import androidx.room.ForeignKey
@@ -35,6 +36,11 @@ data class AllegroPackageLink(
     val waybill: String,
     val statusText: String,
     val readyForPickup: Boolean,
+    @ColumnInfo(defaultValue = "") val pickupCode: String = "",
+    @ColumnInfo(defaultValue = "") val pickupPhoneNumber: String = "",
+    @ColumnInfo(defaultValue = "") val multiboxGroupId: String = "",
+    @ColumnInfo(defaultValue = "") val multiboxIndex: String = "",
+    @ColumnInfo(defaultValue = "") val bundledWith: String = "",
     val statusChangedAt: Instant,
     val lastSeenAt: Instant,
 )
@@ -64,12 +70,17 @@ interface AllegroPackageLinkDao {
          LIMIT 1""")
   suspend fun findByWaybill(accountKey: String, waybill: String): AllegroPackageLink?
 
+  @Query("SELECT * FROM AllegroPackageLink WHERE accountKey = :accountKey")
+  suspend fun getAllForAccount(accountKey: String): List<AllegroPackageLink>
+
   @Query(
-      """UPDATE AllegroPackageLink SET readyForPickup = 0
+      """UPDATE AllegroPackageLink SET readyForPickup = 0, pickupCode = '', pickupPhoneNumber = ''
          WHERE accountKey = :accountKey AND lastSeenAt < :syncStarted""")
   suspend fun revokeUnseenPickupCodes(accountKey: String, syncStarted: Instant)
 
-  @Query("UPDATE AllegroPackageLink SET readyForPickup = 0 WHERE accountKey = :accountKey")
+  @Query(
+      """UPDATE AllegroPackageLink SET readyForPickup = 0, pickupCode = '', pickupPhoneNumber = ''
+         WHERE accountKey = :accountKey""")
   suspend fun revokePickupCodes(accountKey: String)
 
   @Upsert suspend fun upsert(link: AllegroPackageLink)

--- a/app/src/main/java/dev/itsvic/parceltracker/db/AppDatabase.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    version = 5,
+    version = 7,
     entities =
         [Parcel::class, ParcelStatus::class, ParcelHistoryItem::class, AllegroPackageLink::class],
     autoMigrations =
@@ -16,7 +16,9 @@ import androidx.room.TypeConverters
             AutoMigration(from = 2, to = 3),
             AutoMigration(from = 2, to = 4),
             AutoMigration(from = 3, to = 4),
-            AutoMigration(from = 4, to = 5)])
+            AutoMigration(from = 4, to = 5),
+            AutoMigration(from = 5, to = 6),
+            AutoMigration(from = 6, to = 7)])
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
   abstract fun parcelDao(): ParcelDao

--- a/app/src/main/java/dev/itsvic/parceltracker/db/AppDatabase.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/AppDatabase.kt
@@ -7,14 +7,16 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    version = 4,
-    entities = [Parcel::class, ParcelStatus::class, ParcelHistoryItem::class],
+    version = 5,
+    entities =
+        [Parcel::class, ParcelStatus::class, ParcelHistoryItem::class, AllegroPackageLink::class],
     autoMigrations =
         [
             AutoMigration(from = 1, to = 2),
             AutoMigration(from = 2, to = 3),
             AutoMigration(from = 2, to = 4),
-            AutoMigration(from = 3, to = 4)])
+            AutoMigration(from = 3, to = 4),
+            AutoMigration(from = 4, to = 5)])
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
   abstract fun parcelDao(): ParcelDao
@@ -22,4 +24,6 @@ abstract class AppDatabase : RoomDatabase() {
   abstract fun parcelStatusDao(): ParcelStatusDao
 
   abstract fun parcelHistoryDao(): ParcelHistoryDao
+
+  abstract fun allegroPackageLinkDao(): AllegroPackageLinkDao
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/db/Parcel.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/Parcel.kt
@@ -43,6 +43,8 @@ interface ParcelDao {
 
   @Query("SELECT * FROM parcel WHERE id=:id LIMIT 1") fun getById(id: Int): Flow<Parcel>
 
+  @Query("SELECT * FROM parcel WHERE id=:id LIMIT 1") suspend fun getByIdAsync(id: Int): Parcel?
+
   @Transaction
   @Query("SELECT * FROM Parcel WHERE id=:id")
   fun getWithStatusById(id: Int): Flow<ParcelWithStatus>

--- a/app/src/main/java/dev/itsvic/parceltracker/db/ParcelStatus.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/db/ParcelStatus.kt
@@ -8,6 +8,7 @@ import androidx.room.Insert
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.Upsert
 import dev.itsvic.parceltracker.api.Status
 import java.time.Instant
 
@@ -26,6 +27,8 @@ interface ParcelStatusDao {
   @Insert suspend fun insert(status: ParcelStatus)
 
   @Update suspend fun update(status: ParcelStatus)
+
+  @Upsert suspend fun upsert(status: ParcelStatus)
 
   @Delete(entity = ParcelStatus::class) suspend fun deleteByParcelId(parcelId: ParcelId)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/ui/components/PickupCodeDialog.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/ui/components/PickupCodeDialog.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+import dev.itsvic.parceltracker.R
+import dev.itsvic.parceltracker.allegro.AllegroPickupDetails
+
+@Composable
+fun PickupCodeDialog(details: AllegroPickupDetails, onDismiss: () -> Unit) {
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      title = { Text(stringResource(R.string.pickup_code_title)) },
+      text = {
+        Column(
+            modifier = Modifier.verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+          if (details.qrPayload.isNotBlank()) {
+            val bitmap = remember(details.qrPayload) { createQrCode(details.qrPayload) }
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = stringResource(R.string.pickup_qr_code),
+                modifier =
+                    Modifier.fillMaxWidth().aspectRatio(1f).background(Color.White).padding(8.dp),
+            )
+          }
+          if (details.code.isNotBlank()) {
+            Column {
+              Text(
+                  stringResource(R.string.pickup_code),
+                  style = MaterialTheme.typography.labelLarge,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+              SelectionContainer {
+                Text(details.code, style = MaterialTheme.typography.headlineMedium)
+              }
+            }
+          }
+          if (details.phoneNumber.isNotBlank()) {
+            Column {
+              Text(
+                  stringResource(R.string.pickup_phone_number),
+                  style = MaterialTheme.typography.labelLarge,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+              SelectionContainer {
+                Text(details.phoneNumber, style = MaterialTheme.typography.titleLarge)
+              }
+            }
+          }
+        }
+      },
+      confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.close)) } },
+  )
+}
+
+private fun createQrCode(payload: String): Bitmap {
+  val matrix =
+      QRCodeWriter()
+          .encode(
+              payload,
+              BarcodeFormat.QR_CODE,
+              512,
+              512,
+              mapOf(EncodeHintType.MARGIN to 2),
+          )
+  val pixels =
+      IntArray(matrix.width * matrix.height) { index ->
+        if (matrix[index % matrix.width, index / matrix.width]) 0xff000000.toInt()
+        else 0xffffffff.toInt()
+      }
+  return Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.ARGB_8888).apply {
+    setPixels(pixels, 0, matrix.width, 0, 0, matrix.width, matrix.height)
+  }
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/ui/views/ParcelView.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/ui/views/ParcelView.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -60,11 +61,15 @@ fun ParcelView(
     service: Service,
     isArchived: Boolean,
     archivePromptDismissed: Boolean,
+    canEdit: Boolean,
+    showPickupCode: Boolean,
+    pickupCodeLoading: Boolean,
     onBackPressed: () -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
     onArchive: () -> Unit,
     onArchivePromptDismissal: () -> Unit,
+    onShowPickupCode: () -> Unit,
 ) {
   val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
   var expanded by remember { mutableStateOf(false) }
@@ -86,15 +91,17 @@ fun ParcelView(
                   expanded = expanded,
                   onDismissRequest = { expanded = false },
               ) {
-                DropdownMenuItem(
-                    leadingIcon = { Icon(Icons.Filled.Edit, stringResource(R.string.edit)) },
-                    text = { Text(stringResource(R.string.edit)) },
-                    onClick = {
-                      expanded = false
-                      onEdit()
-                    },
-                    contentPadding = MenuItemContentPadding,
-                )
+                if (canEdit) {
+                  DropdownMenuItem(
+                      leadingIcon = { Icon(Icons.Filled.Edit, stringResource(R.string.edit)) },
+                      text = { Text(stringResource(R.string.edit)) },
+                      onClick = {
+                        expanded = false
+                        onEdit()
+                      },
+                      contentPadding = MenuItemContentPadding,
+                  )
+                }
                 if (!isArchived)
                     DropdownMenuItem(
                         leadingIcon = {
@@ -165,6 +172,24 @@ fun ParcelView(
             )
           }
 
+          if (showPickupCode) {
+            item {
+              FilledTonalButton(
+                  onClick = onShowPickupCode,
+                  enabled = !pickupCodeLoading,
+                  modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+              ) {
+                if (pickupCodeLoading) {
+                  CircularProgressIndicator(
+                      modifier = Modifier.padding(end = 12.dp), strokeWidth = 2.dp)
+                }
+                Text(
+                    if (pickupCodeLoading) stringResource(R.string.pickup_code_loading)
+                    else stringResource(R.string.show_pickup_code))
+              }
+            }
+          }
+
           if (!isArchived &&
               !archivePromptDismissed &&
               (parcel.currentStatus == Status.Delivered || parcel.currentStatus == Status.PickedUp))
@@ -232,11 +257,15 @@ private fun ParcelViewPreview() {
         Service.EXAMPLE,
         isArchived = false,
         archivePromptDismissed = false,
+        canEdit = false,
+        showPickupCode = true,
+        pickupCodeLoading = false,
         onBackPressed = {},
         onEdit = {},
         onDelete = {},
         onArchive = {},
         onArchivePromptDismissal = {},
+        onShowPickupCode = {},
     )
   }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/ui/views/SettingsView.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/ui/views/SettingsView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -20,6 +21,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -29,16 +31,21 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -51,6 +58,8 @@ import dev.itsvic.parceltracker.DEMO_MODE
 import dev.itsvic.parceltracker.DHL_API_KEY
 import dev.itsvic.parceltracker.R
 import dev.itsvic.parceltracker.UNMETERED_ONLY
+import dev.itsvic.parceltracker.allegro.AllegroRepository
+import dev.itsvic.parceltracker.allegro.AllegroSessionStore
 import dev.itsvic.parceltracker.api.ParcelHistoryItem
 import dev.itsvic.parceltracker.api.Service
 import dev.itsvic.parceltracker.api.Status
@@ -61,7 +70,11 @@ import dev.itsvic.parceltracker.sendNotification
 import dev.itsvic.parceltracker.ui.components.LogcatButton
 import dev.itsvic.parceltracker.ui.theme.ParcelTrackerTheme
 import java.time.LocalDateTime
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -120,6 +133,8 @@ fun SettingsView(
         }
         SettingsSwitch(checked = unmeteredOnly, onCheckedChange = setUnmeteredOnly)
       }
+
+      AllegroAccountSettings()
 
       Text(
           stringResource(R.string.settings_api_keys),
@@ -197,6 +212,171 @@ fun SettingsView(
     }
   }
 }
+
+@Composable
+private fun AllegroAccountSettings() {
+  val context = LocalContext.current
+  val resources = LocalResources.current
+  val scope = rememberCoroutineScope()
+  val sessionStore = remember(context) { AllegroSessionStore(context) }
+  var session by remember { mutableStateOf(sessionStore.load()) }
+  var username by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
+  var busy by remember { mutableStateOf(false) }
+  var message by remember { mutableStateOf<String?>(null) }
+  val unknownError = stringResource(R.string.error_unknown)
+
+  fun syncComplete(count: Int): String =
+      resources.getQuantityString(R.plurals.allegro_sync_complete, count, count)
+
+  fun syncFailed(error: Throwable): String =
+      resources.getString(R.string.allegro_sync_failed, error.message ?: unknownError)
+
+  Text(
+      stringResource(R.string.settings_accounts),
+      modifier = Modifier.padding(16.dp, 16.dp, 16.dp, 2.dp),
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+  )
+
+  if (session == null) {
+    OutlinedTextField(
+        value = username,
+        onValueChange = { username = it },
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).fillMaxWidth(),
+        label = { Text(stringResource(R.string.allegro_login)) },
+        singleLine = true,
+        enabled = !busy,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+    )
+    OutlinedTextField(
+        value = password,
+        onValueChange = { password = it },
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).fillMaxWidth(),
+        label = { Text(stringResource(R.string.allegro_password)) },
+        singleLine = true,
+        enabled = !busy,
+        visualTransformation = PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+    )
+    FilledTonalButton(
+        onClick = {
+          busy = true
+          message = null
+          scope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                  runSuspendCatching {
+                    val repository = AllegroRepository(context)
+                    val newSession = repository.login(username, password)
+                    newSession to runSuspendCatching { repository.sync() }
+                  }
+                }
+            busy = false
+            result.fold(
+                onSuccess = { (newSession, syncResult) ->
+                  session = newSession
+                  password = ""
+                  message =
+                      syncResult.fold(
+                          onSuccess = ::syncComplete,
+                          onFailure = ::syncFailed,
+                      )
+                },
+                onFailure = {
+                  password = ""
+                  message =
+                      resources.getString(R.string.allegro_login_failed, it.message ?: unknownError)
+                },
+            )
+          }
+        },
+        enabled = !busy && username.isNotBlank() && password.isNotBlank(),
+        modifier = Modifier.padding(16.dp, 8.dp).fillMaxWidth(),
+    ) {
+      Text(
+          if (busy) stringResource(R.string.allegro_logging_in)
+          else stringResource(R.string.allegro_sign_in))
+    }
+  } else {
+    Text(
+        stringResource(R.string.allegro_signed_in_as, session!!.username),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      OutlinedButton(
+          onClick = {
+            busy = true
+            scope.launch {
+              withContext(NonCancellable + Dispatchers.IO) {
+                runSuspendCatching { AllegroRepository(context).logout() }
+              }
+              busy = false
+              session = null
+              message = null
+            }
+          },
+          enabled = !busy,
+          modifier = Modifier.weight(1f),
+      ) {
+        Text(stringResource(R.string.allegro_sign_out))
+      }
+      FilledTonalButton(
+          onClick = {
+            busy = true
+            message = null
+            scope.launch {
+              val result =
+                  withContext(Dispatchers.IO) {
+                    runSuspendCatching { AllegroRepository(context).sync() }
+                  }
+              busy = false
+              result.fold(
+                  onSuccess = { message = syncComplete(it) },
+                  onFailure = {
+                    session = sessionStore.load()
+                    message = syncFailed(it)
+                  },
+              )
+            }
+          },
+          enabled = !busy,
+          modifier = Modifier.weight(1f),
+      ) {
+        Text(
+            if (busy) stringResource(R.string.allegro_syncing)
+            else stringResource(R.string.allegro_sync_now))
+      }
+    }
+  }
+
+  message?.let {
+    Text(
+        it,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+  }
+  Text(
+      stringResource(R.string.allegro_account_detail),
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+  )
+}
+
+private suspend inline fun <T> runSuspendCatching(crossinline action: suspend () -> T): Result<T> =
+    try {
+      Result.success(action())
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      Result.failure(error)
+    }
 
 @Composable
 private fun SettingsSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,21 @@
   <string name="about_app">About app</string>
   <string name="add_a_parcel">Add a parcel</string>
   <string name="add_parcel">Add parcel</string>
+  <string name="allegro_account_detail">Signing in automatically adds packages from your Allegro account and keeps them updated. Your password is never saved.</string>
+  <string name="allegro_logging_in">Signing in…</string>
+  <string name="allegro_login">Allegro login or email</string>
+  <string name="allegro_login_failed">Could not sign in: %1$s</string>
+  <string name="allegro_password">Password</string>
+  <string name="allegro_sign_in">Sign in to Allegro</string>
+  <string name="allegro_sign_out">Sign out</string>
+  <string name="allegro_signed_in_as">Signed in as %1$s</string>
+  <plurals name="allegro_sync_complete">
+    <item quantity="one">Synced %1$d package</item>
+    <item quantity="other">Synced %1$d packages</item>
+  </plurals>
+  <string name="allegro_sync_failed">Package sync failed: %1$s</string>
+  <string name="allegro_sync_now">Sync now</string>
+  <string name="allegro_syncing">Syncing…</string>
   <string name="app_name" translatable="false">Deliveries</string>
   <string name="archive">Archive</string>
   <string name="archive_prompt_question">Do you want to archive this parcel?</string>
@@ -22,8 +37,8 @@
   <string name="edit_parcel">Edit parcel</string>
   <string name="error_json_conversion">There was an error parsing the response, possibly because the API changed.\n\nJSON conversion error message:\n%1$s</string>
   <string name="error_no_api_key_provided">This delivery service requires an API key, but none was provided. Check the app\'s settings for more information.</string>
-  <string name="error_unknown">Unknown error</string>
   <string name="error_unexpected_detail">An unexpected error was encountered with the message:\n%1$s.</string>
+  <string name="error_unknown">Unknown error</string>
   <string name="go_back">Go back</string>
   <string name="human_name_error_text">Name must not be blank.</string>
   <string name="ignore">Ignore</string>
@@ -31,20 +46,29 @@
   <string name="more_options">More options</string>
   <string name="network_failure_detail">Your device may be offline, the service\'s servers may be offline, or the details you have entered are incorrect.</string>
   <string name="no_parcels_flavor">You currently do not have any parcels.</string>
+  <string name="parcel_category_normal">Normal</string>
+  <string name="parcel_category_synced">Synced</string>
   <string name="parcel_doesnt_exist_detail">This parcel does not exist on the delivery service\'s servers yet. Make sure the parcel details are correct.</string>
   <string name="parcel_history">Parcel history</string>
   <string name="parcel_name">Name</string>
+  <string name="pickup_code">Pickup code</string>
+  <string name="pickup_code_fetch_failed">Could not load the pickup code: %1$s</string>
+  <string name="pickup_code_loading">Loading pickup code…</string>
+  <string name="pickup_code_title">Package pickup</string>
+  <string name="pickup_phone_number">Phone number</string>
+  <string name="pickup_qr_code">Pickup QR code</string>
   <string name="postal_code">Postal code</string>
   <string name="postal_code_error_text">Postal code must not be blank.</string>
   <string name="property_delivery_time">Delivered at</string>
   <string name="property_eta">ETA</string>
+  <string name="property_multibox">Multibox</string>
   <string name="property_pickup_point">Pickup point</string>
   <string name="property_weight">Weight</string>
   <string name="repository">Repository</string>
   <string name="save">Save</string>
   <string name="service_4px" translatable="false">4PX</string>
-  <string name="service_allegro_onebox">Allegro OneBox</string>
   <string name="service_allegro_account">Allegro</string>
+  <string name="service_allegro_onebox">Allegro OneBox</string>
   <string name="service_an_post" translatable="false">An Post</string>
   <string name="service_belpost">Belpost</string>
   <string name="service_cainiao" translatable="false">Cainiao</string>
@@ -81,6 +105,7 @@
   <string name="settings_accounts">Accounts</string>
   <string name="settings_api_keys">API keys</string>
   <string name="settings_experimental">Experimental</string>
+  <string name="show_pickup_code">Show pickup code</string>
   <string name="specify_a_postal_code">Specify a postal code</string>
   <string name="specify_postal_code_flavor_text">Optional. You may be able to access extra information, such as location, with a postal code.</string>
   <string name="status_awaiting_pickup">Awaiting pickup</string>
@@ -113,26 +138,4 @@
   <string name="tracking_id_error_text">Tracking ID must not be blank.</string>
   <string name="unmetered_only_setting">Update only on unmetered networks</string>
   <string name="unmetered_only_setting_detail">If enabled, Deliveries will look for parcel updates only on unmetered connections, such as your home Wi-Fi.</string>
-  <string name="allegro_account_detail">Signing in automatically adds packages from your Allegro account and keeps them updated. Your password is never saved.</string>
-  <string name="allegro_login">Allegro login or email</string>
-  <string name="allegro_login_failed">Could not sign in: %1$s</string>
-  <string name="allegro_logging_in">Signing in&#8230;</string>
-  <string name="allegro_password">Password</string>
-  <string name="allegro_sign_in">Sign in to Allegro</string>
-  <string name="allegro_sign_out">Sign out</string>
-  <string name="allegro_signed_in_as">Signed in as %1$s</string>
-  <plurals name="allegro_sync_complete">
-    <item quantity="one">Synced %1$d package</item>
-    <item quantity="other">Synced %1$d packages</item>
-  </plurals>
-  <string name="allegro_sync_failed">Package sync failed: %1$s</string>
-  <string name="allegro_sync_now">Sync now</string>
-  <string name="allegro_syncing">Syncing&#8230;</string>
-  <string name="pickup_code">Pickup code</string>
-  <string name="pickup_code_fetch_failed">Could not load the pickup code: %1$s</string>
-  <string name="pickup_code_loading">Loading pickup code&#8230;</string>
-  <string name="pickup_code_title">Package pickup</string>
-  <string name="pickup_phone_number">Phone number</string>
-  <string name="pickup_qr_code">Pickup QR code</string>
-  <string name="show_pickup_code">Show pickup code</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
   <string name="archive_prompt_text">If you archive this parcel, its history will be preserved on device. It will not be periodically checked for updates.</string>
   <string name="channel_description">Notifications about the current status of the parcel</string>
   <string name="channel_name">Parcel events</string>
+  <string name="close">Close</string>
   <string name="current_status">Current status</string>
   <string name="delete">Delete</string>
   <string name="delivery_service">Delivery service</string>
@@ -21,6 +22,7 @@
   <string name="edit_parcel">Edit parcel</string>
   <string name="error_json_conversion">There was an error parsing the response, possibly because the API changed.\n\nJSON conversion error message:\n%1$s</string>
   <string name="error_no_api_key_provided">This delivery service requires an API key, but none was provided. Check the app\'s settings for more information.</string>
+  <string name="error_unknown">Unknown error</string>
   <string name="error_unexpected_detail">An unexpected error was encountered with the message:\n%1$s.</string>
   <string name="go_back">Go back</string>
   <string name="human_name_error_text">Name must not be blank.</string>
@@ -36,11 +38,13 @@
   <string name="postal_code_error_text">Postal code must not be blank.</string>
   <string name="property_delivery_time">Delivered at</string>
   <string name="property_eta">ETA</string>
+  <string name="property_pickup_point">Pickup point</string>
   <string name="property_weight">Weight</string>
   <string name="repository">Repository</string>
   <string name="save">Save</string>
   <string name="service_4px" translatable="false">4PX</string>
   <string name="service_allegro_onebox">Allegro OneBox</string>
+  <string name="service_allegro_account">Allegro</string>
   <string name="service_an_post" translatable="false">An Post</string>
   <string name="service_belpost">Belpost</string>
   <string name="service_cainiao" translatable="false">Cainiao</string>
@@ -74,6 +78,7 @@
   <string name="service_uniuni" translatable="false">UniUni</string>
   <string name="service_ups" translatable="false">UPS</string>
   <string name="settings">Settings</string>
+  <string name="settings_accounts">Accounts</string>
   <string name="settings_api_keys">API keys</string>
   <string name="settings_experimental">Experimental</string>
   <string name="specify_a_postal_code">Specify a postal code</string>
@@ -108,4 +113,26 @@
   <string name="tracking_id_error_text">Tracking ID must not be blank.</string>
   <string name="unmetered_only_setting">Update only on unmetered networks</string>
   <string name="unmetered_only_setting_detail">If enabled, Deliveries will look for parcel updates only on unmetered connections, such as your home Wi-Fi.</string>
+  <string name="allegro_account_detail">Signing in automatically adds packages from your Allegro account and keeps them updated. Your password is never saved.</string>
+  <string name="allegro_login">Allegro login or email</string>
+  <string name="allegro_login_failed">Could not sign in: %1$s</string>
+  <string name="allegro_logging_in">Signing in&#8230;</string>
+  <string name="allegro_password">Password</string>
+  <string name="allegro_sign_in">Sign in to Allegro</string>
+  <string name="allegro_sign_out">Sign out</string>
+  <string name="allegro_signed_in_as">Signed in as %1$s</string>
+  <plurals name="allegro_sync_complete">
+    <item quantity="one">Synced %1$d package</item>
+    <item quantity="other">Synced %1$d packages</item>
+  </plurals>
+  <string name="allegro_sync_failed">Package sync failed: %1$s</string>
+  <string name="allegro_sync_now">Sync now</string>
+  <string name="allegro_syncing">Syncing&#8230;</string>
+  <string name="pickup_code">Pickup code</string>
+  <string name="pickup_code_fetch_failed">Could not load the pickup code: %1$s</string>
+  <string name="pickup_code_loading">Loading pickup code&#8230;</string>
+  <string name="pickup_code_title">Package pickup</string>
+  <string name="pickup_phone_number">Phone number</string>
+  <string name="pickup_qr_code">Pickup QR code</string>
+  <string name="show_pickup_code">Show pickup code</string>
 </resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,5 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="allegro_session.xml"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,9 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="allegro_session.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="allegro_session.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/app/src/release/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
+++ b/app/src/release/java/dev/itsvic/parceltracker/allegro/AllegroDebugInterceptor.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import android.content.Context
+import okhttp3.Interceptor
+
+@Suppress("UNUSED_PARAMETER")
+internal fun createAllegroDebugInterceptor(context: Context): Interceptor? = null

--- a/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroClientTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroClientTest.kt
@@ -10,7 +10,9 @@ import okio.GzipSink
 import okio.buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -113,6 +115,60 @@ class AllegroClientTest {
     )
     assertEquals("application/vnd.allegro.beta.v1+json", pickupRequest.headers["Accept"])
   }
+
+  @Test
+  fun treatsForbiddenResponseAsTransientAndKeepsSession() = runBlocking {
+    server.enqueue(
+        MockResponse.Builder()
+            .code(403)
+            .addHeader("Set-Cookie", "datadome=updated; Path=/")
+            .body("""{"url":"https://captcha.invalid/interstitial"}""")
+            .build())
+    val client = authenticatedClient()
+
+    val error =
+        try {
+          client.fetchDashboard()
+          fail("Expected a forbidden response")
+          null
+        } catch (error: AllegroException) {
+          error
+        }
+
+    assertFalse(error is AllegroSessionExpiredException)
+    assertEquals(403, error?.statusCode)
+    assertEquals("updated", client.session?.datadome)
+  }
+
+  @Test
+  fun expiresSessionForUnauthorizedResponse() = runBlocking {
+    server.enqueue(MockResponse.Builder().code(401).build())
+    val client = authenticatedClient()
+
+    val error =
+        try {
+          client.fetchDashboard()
+          fail("Expected an unauthorized response")
+          null
+        } catch (error: AllegroException) {
+          error
+        }
+
+    assertTrue(error is AllegroSessionExpiredException)
+  }
+
+  private fun authenticatedClient() =
+      AllegroClient(
+          session =
+              AllegroSession(
+                  username = "nyx",
+                  accessToken = "token",
+                  wdctx = "wd",
+                  datadome = "dd",
+              ),
+          allegroUrl = server.url("/"),
+          edgeUrl = server.url("/"),
+      )
 
   private fun gzip(value: String) =
       Buffer().apply { GzipSink(this).buffer().use { sink -> sink.writeUtf8(value) } }

--- a/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroClientTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroClientTest.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okio.Buffer
+import okio.GzipSink
+import okio.buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AllegroClientTest {
+  private lateinit var server: MockWebServer
+
+  @Before
+  fun setUp() {
+    server = MockWebServer()
+    server.start()
+  }
+
+  @After
+  fun tearDown() {
+    server.close()
+  }
+
+  @Test
+  fun performsAndroidLoginFlow() = runBlocking {
+    server.enqueue(
+        MockResponse.Builder()
+            .code(204)
+            .addHeader("Set-Cookie", "wdctx=wd; Path=/")
+            .addHeader("Set-Cookie", "datadome=dd; Path=/")
+            .build())
+    server.enqueue(
+        MockResponse.Builder().code(200).addHeader("Set-Cookie", "QXLSESSID=qx; Path=/").build())
+    server.enqueue(
+        MockResponse.Builder()
+            .code(200)
+            .body(
+                """{"accessToken":"token","accessTokenExpiration":"2026-08-11T00:00:00Z","username":"testuser"}""")
+            .build())
+    val client = AllegroClient(allegroUrl = server.url("/"), edgeUrl = server.url("/"))
+
+    val session = client.login("testuser", "testpass")
+
+    assertEquals("token", session.accessToken)
+    assertEquals("wd", session.wdctx)
+    assertEquals("dd", session.datadome)
+    assertEquals("qx", session.qxlsessid)
+    val check = server.takeRequest(1, TimeUnit.SECONDS)!!
+    val initialization = server.takeRequest(1, TimeUnit.SECONDS)!!
+    val verification = server.takeRequest(1, TimeUnit.SECONDS)!!
+    assertEquals("HEAD", check.method)
+    assertEquals("/client-check", check.url.encodedPath)
+    assertEquals("/authentication/initialization/mobile", initialization.url.encodedPath)
+    assertEquals("/authentication/credentials/mobile/verification", verification.url.encodedPath)
+    assertEquals("{\"login\":\"testuser\",\"password\":\"testpass\"}", verification.body!!.utf8())
+    assertTrue(verification.headers["Cookie"]!!.contains("QXLSESSID=qx"))
+  }
+
+  @Test
+  fun fetchesDashboardAndPickupDetails() = runBlocking {
+    server.enqueue(
+        MockResponse.Builder()
+            .addHeader("Content-Encoding", "gzip")
+            .body(gzip("""{"total":1,"parcelsForPickup":1}"""))
+            .build())
+    server.enqueue(
+        MockResponse.Builder()
+            .body(
+                """{"packages":[{"id":"A00TEST001","title":"Sample item","status":"Gotowa do odbioru","carrier":"Allegro One","carrierId":"ALLEGRO","trackingNumber":"A00TEST001"}]}""")
+            .build())
+    server.enqueue(
+        MockResponse.Builder()
+            .body(
+                """{"waybill":"A00TEST001","carrierId":"ALLEGRO","carrierName":"Allegro One","formattedCode":"000 000","formattedPhoneNumber":"+48 000 000 000","qrCode":"test-qr-payload"}""")
+            .build())
+    val client =
+        AllegroClient(
+            session =
+                AllegroSession(
+                    username = "testuser",
+                    accessToken = "token",
+                    wdctx = "wd",
+                    datadome = "dd",
+                ),
+            allegroUrl = server.url("/"),
+            edgeUrl = server.url("/"),
+        )
+
+    val packages = client.fetchDashboard()
+    val pickup = client.fetchPickupDetails("ALLEGRO", "A00TEST001")
+
+    assertEquals(1, packages.size)
+    assertTrue(packages.single().readyForPickup)
+    assertEquals("000 000", pickup.code)
+    assertEquals("+48 000 000 000", pickup.phoneNumber)
+    assertEquals("test-qr-payload", pickup.qrPayload)
+    val summaryRequest = server.takeRequest(1, TimeUnit.SECONDS)!!
+    val renderRequest = server.takeRequest(1, TimeUnit.SECONDS)!!
+    val pickupRequest = server.takeRequest(1, TimeUnit.SECONDS)!!
+    assertEquals("application/vnd.allegro.internal.v2+json", summaryRequest.headers["Accept"])
+    assertEquals("gzip", summaryRequest.headers["Accept-Encoding"])
+    assertEquals("/mobile/render", renderRequest.url.encodedPath)
+    assertEquals(
+        "/packages/carrier/ALLEGRO/waybill/A00TEST001/pickup-details",
+        pickupRequest.url.encodedPath,
+    )
+    assertEquals("application/vnd.allegro.beta.v1+json", pickupRequest.headers["Accept"])
+  }
+
+  private fun gzip(value: String) =
+      Buffer().apply { GzipSink(this).buffer().use { sink -> sink.writeUtf8(value) } }
+}

--- a/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroParserTest.kt
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package dev.itsvic.parceltracker.allegro
 
+import dev.itsvic.parceltracker.api.Status
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AllegroParserTest {
@@ -102,5 +105,168 @@ class AllegroParserTest {
 
     assertEquals("Przesyłka dzisiaj w punkcie", details.status)
     assertEquals("Przekazana do doręczenia", details.history.single().status)
+    assertEquals(Status.InTransit, AllegroParser.statusToAppStatus(details.status))
+  }
+
+  @Test
+  fun parsesMultiboxPickupStatus() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "id" to "ALLEGRO:A00TEST002",
+                "childComponents" to
+                    listOf(
+                        mapOf("text" to "Odbierz przesyłki"),
+                        mapOf("text" to "multibox"),
+                        mapOf("text" to "A00TEST002"),
+                        mapOf("text" to "1 z 2 przesyłek"),
+                        mapOf("text" to "Sample multibox product"),
+                        mapOf("text" to "ODBIERZ Z MULTIBOXA"),
+                    ),
+                "actions" to
+                    listOf(
+                        mapOf(
+                            "trigger" to "click",
+                            "action" to
+                                mapOf(
+                                    "topic" to "share",
+                                    "payload" to
+                                        mapOf(
+                                            "content" to
+                                                "Odbierz za mnie przesyłkę z Multiboxa do czw. 13 sie 14:46 z Allegro One Box - TEST01, Example Street 1, Example City. Nr odbiorcy: 000 000 000. Kod odbioru: 111 222. Nr przesyłki A00TEST002.",
+                                            "contentType" to "text"))),
+                    ),
+            ))
+
+    assertEquals(1, packages.size)
+    assertEquals("Odbierz przesyłki", packages.single().status)
+    assertTrue(packages.single().readyForPickup)
+    assertEquals("111 222", packages.single().pickupCode)
+    assertEquals("000 000 000", packages.single().pickupPhoneNumber)
+    assertEquals(
+        Status.AwaitingPickup,
+        AllegroParser.statusToAppStatus(packages.single().status, packages.single().readyForPickup),
+    )
+  }
+
+  @Test
+  fun parsesPickupCredentialsFromSingleBoxCardSharePayload() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "id" to "ALLEGRO:A00TEST003",
+                "childComponents" to
+                    listOf(
+                        mapOf("text" to "Odbierz przesyłkę"),
+                        mapOf("text" to "A00TEST003"),
+                        mapOf("text" to "Sample product"),
+                        mapOf("text" to "ODBIERZ"),
+                    ),
+                "actions" to
+                    listOf(
+                        mapOf(
+                            "trigger" to "click",
+                            "action" to
+                                mapOf(
+                                    "topic" to "share",
+                                    "payload" to
+                                        mapOf(
+                                            "content" to
+                                                "Odbierz za mnie przesyłkę do czw. 13 sie 14:14 z Allegro One Box - TEST01, Example Street 1, Example City. Nr odbiorcy: 000 000 000. Kod odbioru: 333 444. Nr przesyłki A00TEST003.",
+                                            "contentType" to "text"))),
+                    ),
+            ))
+
+    assertEquals(1, packages.size)
+    assertEquals("333 444", packages.single().pickupCode)
+    assertEquals("000 000 000", packages.single().pickupPhoneNumber)
+    assertTrue(packages.single().readyForPickup)
+  }
+
+  @Test
+  fun preservesPickupCredentialsWithoutSharePayload() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "id" to "ALLEGRO:A00TEST004",
+                "childComponents" to
+                    listOf(
+                        mapOf("text" to "W drodze"),
+                        mapOf("text" to "A00TEST004"),
+                        mapOf("text" to "Sample product"),
+                    ),
+            ))
+
+    assertEquals(1, packages.size)
+    assertEquals("", packages.single().pickupCode)
+    assertEquals("", packages.single().pickupPhoneNumber)
+    assertFalse(packages.single().readyForPickup)
+  }
+
+  @Test
+  fun parsesMultiboxGroupMarkers() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "id" to "ALLEGRO:A00GROUP001",
+                "childComponents" to
+                    listOf(
+                        mapOf("text" to "Odbierz przesyłki"),
+                        mapOf("text" to "multibox"),
+                        mapOf("text" to "A00GROUP001"),
+                        mapOf("text" to "1 z 2 przesyłek"),
+                        mapOf("text" to "Sample multibox product"),
+                        mapOf("text" to "ODBIERZ Z MULTIBOXA"),
+                        mapOf("text" to "POKAŻ WSZYSTKIE PRZESYŁKI"),
+                    ),
+                "actions" to
+                    listOf(
+                        mapOf(
+                            "trigger" to "click",
+                            "action" to
+                                mapOf(
+                                    "url" to
+                                        "allegro-mbox://render?boxId=ALLEGRO_A00GROUP001&route=https%3A%2F%2Fallegro.pl%2F",
+                                    "type" to "open"))),
+            ))
+
+    assertEquals(1, packages.size)
+    assertEquals("ALLEGRO_A00GROUP001", packages.single().multiboxGroupId)
+    assertEquals("1 z 2 przesyłek", packages.single().multiboxIndex)
+  }
+
+  @Test
+  fun ignoresBoxIdFromAnalyticsPayloads() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "id" to "ALLEGRO:A00TEST005",
+                "childComponents" to
+                    listOf(
+                        mapOf("text" to "Odbierz przesyłkę"),
+                        mapOf("text" to "A00TEST005"),
+                        mapOf("text" to "Sample product"),
+                        mapOf("text" to "ODBIERZ"),
+                    ),
+                "actions" to
+                    listOf(
+                        mapOf(
+                            "action" to
+                                mapOf(
+                                    "events" to
+                                        listOf(
+                                            mapOf(
+                                                "customParams" to
+                                                    mapOf(
+                                                        "orderId" to
+                                                            "00000000-0000-0000-0000-000000000001",
+                                                        "_opbox" to
+                                                            mapOf(
+                                                                "boxId" to
+                                                                    "test-box-id"))))))),
+            ))
+
+    assertEquals(1, packages.size)
+    assertEquals("", packages.single().multiboxGroupId)
   }
 }

--- a/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/allegro/AllegroParserTest.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.allegro
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AllegroParserTest {
+  @Test
+  fun parsesCurrentAndroidCardsWithoutActionLabels() {
+    val packages =
+        AllegroParser.parsePackages(
+            mapOf(
+                "content" to
+                    mapOf(
+                        "component" to
+                            mapOf(
+                                "childComponents" to
+                                    listOf(
+                                        mapOf(
+                                            "id" to "ALLEGRO:A00TEST001",
+                                            "childComponents" to
+                                                listOf(
+                                                    mapOf(
+                                                        "accessibility" to
+                                                            mapOf("label" to "Dodatkowe opcje"),
+                                                        "actions" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "action" to
+                                                                        mapOf(
+                                                                            "waybill" to
+                                                                                "A00TEST001")))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "text" to
+                                                                        "Przesyłka oczekuje na nadanie"))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "text" to
+                                                                        "Przewidywana dostawa: jutro"))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "text" to
+                                                                        "Allegro One Box - TST01"))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(mapOf("text" to "A00TEST001"))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "text" to
+                                                                        "Sample product name"))),
+                                                    mapOf(
+                                                        "childComponents" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "text" to
+                                                                        "SZCZEGÓŁY DOSTAWY"))),
+                                                )),
+                                    )))))
+
+    assertEquals(1, packages.size)
+    assertEquals("Sample product name", packages.single().title)
+    assertEquals("ALLEGRO", packages.single().carrierId)
+    assertEquals("Allegro One", packages.single().carrier)
+    assertEquals("Allegro One Box - TST01", packages.single().pickupPoint)
+  }
+
+  @Test
+  fun parsesTrackingHistoryFromDetails() {
+    val original =
+        AllegroPackage(
+            packageId = "pkg-test-001",
+            title = "Sample item",
+            status = "W drodze",
+            carrier = "InPost",
+            trackingNumber = "520000000000000000000000",
+        )
+    val details =
+        AllegroParser.parsePackageDetails(
+            mapOf(
+                "content" to
+                    mapOf(
+                        "component" to
+                            mapOf(
+                                "childComponents" to
+                                    listOf(
+                                        mapOf("text" to "Przesyłka dzisiaj w punkcie"),
+                                        mapOf("text" to "Historia przesyłki"),
+                                        mapOf("text" to "Przekazana do doręczenia"),
+                                        mapOf("text" to "10 sie 2026, 07:49"),
+                                    )))),
+            original,
+        )
+
+    assertEquals("Przesyłka dzisiaj w punkcie", details.status)
+    assertEquals("Przekazana do doręczenia", details.history.single().status)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ work = "2.11.2"
 kotlinxCoroutinesGuava = "1.11.0"
 material3 = "1.5.0-alpha24"
 browser = "1.10.0"
+zxing = "3.5.4"
+chucker = "4.3.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -45,6 +47,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-coroutines = { group = "com.squareup.okhttp3", name = "okhttp-coroutines", version.ref = "okhttp" }
 logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver3", version.ref = "okhttp" }
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigation" }
@@ -61,6 +64,8 @@ work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "
 work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinxCoroutinesGuava" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
+zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
+chucker = { group = "com.github.chuckerteam.chucker", name = "library", version.ref = "chucker" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR adds support for logging into your allegro account and syncing packages from it to the app.

Todo:
- the app loses the allegro session after closing the app (or clearing its cache)
- add tabbed settings (accounts and preferences tabs) 
- test allegro code generation and pickup qr generation (inpost is field tested thankfully)
- port material3 settings categories and items from metrolist-KMP

Current state: sync works, you can log into your account, notifications work, chucker was added to help with development