### PR TITLE
feat: share/open tracking links to add a parcel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
                 <data android:scheme="https" android:host="www.ups.com" />
                 <data android:scheme="https" android:host="gls-group.eu" />
                 <data android:scheme="https" android:host="gls-group.com" />
+                <data android:scheme="https" android:host="www.gls-info.nl" />
                 <data android:scheme="https" android:host="inpost.pl" />
                 <data android:scheme="https" android:host="www.inpost.pl" />
                 <data android:scheme="https" android:host="jouw.postnl.nl" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,10 +21,40 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.ParcelTracker.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Share target: lets users share a tracking URL (e.g. from a browser
+                 or email app) directly into the Add Parcel form. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
+            <!-- App Links for known courier tracking domains. Deliberately NOT
+                 autoVerify="true": we don't own these third-party domains and
+                 can't host assetlinks.json on them, so Digital Asset Links
+                 verification would just fail. A plain VIEW + BROWSABLE + DEFAULT
+                 filter is what lets users manually opt in via
+                 Settings > Apps > Deliveries > Open by default > Add link. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="my.dhlparcel.nl" />
+                <data android:scheme="https" android:host="www.ups.com" />
+                <data android:scheme="https" android:host="gls-group.eu" />
+                <data android:scheme="https" android:host="gls-group.com" />
+                <data android:scheme="https" android:host="www.gls-info.nl" />
+                <data android:scheme="https" android:host="inpost.pl" />
+                <data android:scheme="https" android:host="www.inpost.pl" />
+                <data android:scheme="https" android:host="jouw.postnl.nl" />
+                <data android:scheme="https" android:host="emonitoring.poczta-polska.pl" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,7 +50,6 @@
                 <data android:scheme="https" android:host="www.ups.com" />
                 <data android:scheme="https" android:host="gls-group.eu" />
                 <data android:scheme="https" android:host="gls-group.com" />
-                <data android:scheme="https" android:host="www.gls-info.nl" />
                 <data android:scheme="https" android:host="inpost.pl" />
                 <data android:scheme="https" android:host="www.inpost.pl" />
                 <data android:scheme="https" android:host="jouw.postnl.nl" />

--- a/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
@@ -74,92 +74,91 @@ import kotlinx.serialization.Serializable
 import okio.IOException
 
 class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+  override fun onCreate(savedInstanceState: Bundle?) {
+    installSplashScreen()
+    super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-            handleNotificationPermissionStuff()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) handleNotificationPermissionStuff()
 
-        parcelToOpen = mutableIntStateOf(intent.getIntExtra("openParcel", -1))
-        addParcelIntent = mutableStateOf(resolveAddParcelIntent(intent))
+    parcelToOpen = mutableIntStateOf(intent.getIntExtra("openParcel", -1))
+    addParcelIntent = mutableStateOf(resolveAddParcelIntent(intent))
 
-        setContent {
-            val parcelToOpen by parcelToOpen
-            val addParcelIntent by addParcelIntent
+    setContent {
+      val parcelToOpen by parcelToOpen
+      val addParcelIntent by addParcelIntent
 
-            ParcelTrackerTheme {
-                Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.background)) {
-                    ParcelAppNavigation(parcelToOpen, addParcelIntent)
-                }
-            }
+      ParcelTrackerTheme {
+        Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.background)) {
+          ParcelAppNavigation(parcelToOpen, addParcelIntent)
         }
+      }
     }
+  }
 
-    companion object {
-        lateinit var parcelToOpen: MutableIntState
-        lateinit var addParcelIntent: MutableState<AddParcelPage?>
+  companion object {
+    lateinit var parcelToOpen: MutableIntState
+    lateinit var addParcelIntent: MutableState<AddParcelPage?>
 
-        // Resolves a share (ACTION_SEND) or deep link (ACTION_VIEW) intent into
-        // an AddParcelPage prefill, if any. Returns null for intents that aren't
-        // asking to add a parcel at all (e.g. the initial MAIN/LAUNCHER intent).
-        private fun resolveAddParcelIntent(intent: Intent): AddParcelPage? {
-            return when (intent.action) {
-                Intent.ACTION_SEND -> {
-                    if (intent.type != "text/plain") null
-                    else {
-                        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-                        val match = text?.let { parseSharedText(it) }
-                        AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
-                    }
-                }
-                Intent.ACTION_VIEW -> {
-                    val data = intent.data
-                    if (data == null) null
-                    else {
-                        val match = parseTrackingUrl(data.toString())
-                        AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
-                    }
-                }
-                else -> null
-            }
+    // Resolves a share (ACTION_SEND) or deep link (ACTION_VIEW) intent into
+    // an AddParcelPage prefill, if any. Returns null for intents that aren't
+    // asking to add a parcel at all (e.g. the initial MAIN/LAUNCHER intent).
+    private fun resolveAddParcelIntent(intent: Intent): AddParcelPage? {
+      return when (intent.action) {
+        Intent.ACTION_SEND -> {
+          if (intent.type != "text/plain") null
+          else {
+            val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+            val match = text?.let { parseSharedText(it) }
+            AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
+          }
         }
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        setIntent(intent)
-        parcelToOpen.intValue = intent.getIntExtra("openParcel", -1)
-        resolveAddParcelIntent(intent)?.let { addParcelIntent.value = it }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    fun handleNotificationPermissionStuff() {
-        val requestPermissionLauncher =
-            registerForActivityResult(ActivityResultContracts.RequestPermission()) {
-                isGranted: Boolean ->
-                if (isGranted) {
-                    Log.d("MainActivity", "Notification permissions granted")
-                } else {
-                    Log.d("MainActivity", "Notification permissions NOT granted")
-                }
-            }
-
-        // Notification checks
-        when {
-            ContextCompat.checkSelfPermission(
-                applicationContext,
-                Manifest.permission.POST_NOTIFICATIONS,
-            ) == PackageManager.PERMISSION_GRANTED -> {
-                // We can post notifications
-            }
-            // TODO: educational UI maybe?
-            else -> {
-                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
+        Intent.ACTION_VIEW -> {
+          val data = intent.data
+          if (data == null) null
+          else {
+            val match = parseTrackingUrl(data.toString())
+            AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
+          }
         }
+        else -> null
+      }
     }
+  }
+
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    parcelToOpen.intValue = intent.getIntExtra("openParcel", -1)
+    resolveAddParcelIntent(intent)?.let { addParcelIntent.value = it }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+  fun handleNotificationPermissionStuff() {
+    val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean
+          ->
+          if (isGranted) {
+            Log.d("MainActivity", "Notification permissions granted")
+          } else {
+            Log.d("MainActivity", "Notification permissions NOT granted")
+          }
+        }
+
+    // Notification checks
+    when {
+      ContextCompat.checkSelfPermission(
+          applicationContext,
+          Manifest.permission.POST_NOTIFICATIONS,
+      ) == PackageManager.PERMISSION_GRANTED -> {
+        // We can post notifications
+      }
+      // TODO: educational UI maybe?
+      else -> {
+        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+      }
+    }
+  }
 }
 
 @Serializable object HomePage
@@ -179,273 +178,266 @@ data class AddParcelPage(
 
 @Composable
 fun ParcelAppNavigation(parcelToOpen: Int, addParcelIntent: AddParcelPage?) {
-    val db = ParcelApplication.db
-    val navController = rememberNavController()
-    val scope = rememberCoroutineScope()
-    val context = LocalContext.current
-    val preferences by context.dataStore.data.collectAsState(emptyPreferences())
-    val demoMode = preferences[DEMO_MODE] == true
-    val demoModeActionBlock = stringResource(R.string.demo_mode_action_block)
+  val db = ParcelApplication.db
+  val navController = rememberNavController()
+  val scope = rememberCoroutineScope()
+  val context = LocalContext.current
+  val preferences by context.dataStore.data.collectAsState(emptyPreferences())
+  val demoMode = preferences[DEMO_MODE] == true
+  val demoModeActionBlock = stringResource(R.string.demo_mode_action_block)
 
-    LaunchedEffect(parcelToOpen) {
-        if (parcelToOpen != -1) {
-            navController.navigate(route = ParcelPage(parcelToOpen)) { popUpTo(HomePage) }
-        }
+  LaunchedEffect(parcelToOpen) {
+    if (parcelToOpen != -1) {
+      navController.navigate(route = ParcelPage(parcelToOpen)) { popUpTo(HomePage) }
+    }
+  }
+
+  LaunchedEffect(addParcelIntent) {
+    if (addParcelIntent != null) {
+      navController.navigate(route = addParcelIntent) { popUpTo(HomePage) }
+      MainActivity.addParcelIntent.value = null
+    }
+  }
+
+  val animDuration = 300
+
+  NavHost(
+      navController = navController,
+      startDestination = HomePage,
+      enterTransition = {
+        slideIntoContainer(
+            towards = AnimatedContentTransitionScope.SlideDirection.Start,
+            animationSpec = tween(animDuration),
+            initialOffset = { it / 4 },
+        ) + fadeIn(tween(animDuration))
+      },
+      exitTransition = { fadeOut(tween(animDuration)) + scaleOut(tween(500), 0.9f) },
+      popEnterTransition = { fadeIn(tween(animDuration)) + scaleIn(tween(500), 0.9f) },
+      popExitTransition = {
+        slideOutOfContainer(
+            towards = AnimatedContentTransitionScope.SlideDirection.Start,
+            animationSpec = tween(animDuration),
+            targetOffset = { -it / 4 },
+        ) + fadeOut(tween(animDuration))
+      },
+  ) {
+    composable<HomePage> {
+      val parcels =
+          if (demoMode) demoModeParcels
+          else db.parcelDao().getAllWithStatus().collectAsState(initial = emptyList()).value
+
+      HomeView(
+          parcels = parcels,
+          onNavigateToAddParcel = { navController.navigate(route = AddParcelPage()) },
+          onNavigateToParcel = { navController.navigate(route = ParcelPage(it.id)) },
+          onNavigateToSettings = { navController.navigate(route = SettingsPage) },
+      )
     }
 
-    LaunchedEffect(addParcelIntent) {
-        if (addParcelIntent != null) {
-            navController.navigate(route = addParcelIntent) { popUpTo(HomePage) }
-            MainActivity.addParcelIntent.value = null
-        }
-    }
+    composable<SettingsPage> { SettingsView(onBackPressed = { navController.popBackStack() }) }
 
-    val animDuration = 300
+    composable<ParcelPage> { backStackEntry ->
+      val route: ParcelPage = backStackEntry.toRoute()
+      val parcelWithStatus: ParcelWithStatus? =
+          if (demoMode) demoModeParcels[route.parcelDbId]
+          else db.parcelDao().getWithStatusById(route.parcelDbId).collectAsState(null).value
+      val dbHistory: List<dev.itsvic.parceltracker.db.ParcelHistoryItem> by
+          db.parcelHistoryDao().getAllById(route.parcelDbId).collectAsState(listOf())
+      var apiParcel: APIParcel? by remember { mutableStateOf(null) }
+      val networkFailureDetail = stringResource(R.string.network_failure_detail)
+      val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
+      val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
+      val jsonConversionError = stringResource(R.string.error_json_conversion)
+      val unexpectedErrorDetail = stringResource(R.string.error_unexpected_detail)
 
-    NavHost(
-        navController = navController,
-        startDestination = HomePage,
-        enterTransition = {
-            slideIntoContainer(
-                towards = AnimatedContentTransitionScope.SlideDirection.Start,
-                animationSpec = tween(animDuration),
-                initialOffset = { it / 4 },
-            ) + fadeIn(tween(animDuration))
-        },
-        exitTransition = { fadeOut(tween(animDuration)) + scaleOut(tween(500), 0.9f) },
-        popEnterTransition = { fadeIn(tween(animDuration)) + scaleIn(tween(500), 0.9f) },
-        popExitTransition = {
-            slideOutOfContainer(
-                towards = AnimatedContentTransitionScope.SlideDirection.Start,
-                animationSpec = tween(animDuration),
-                targetOffset = { -it / 4 },
-            ) + fadeOut(tween(animDuration))
-        },
-    ) {
-        composable<HomePage> {
-            val parcels =
-                if (demoMode) demoModeParcels
-                else db.parcelDao().getAllWithStatus().collectAsState(initial = emptyList()).value
+      val dbParcel = parcelWithStatus?.parcel
 
-            HomeView(
-                parcels = parcels,
-                onNavigateToAddParcel = { navController.navigate(route = AddParcelPage()) },
-                onNavigateToParcel = { navController.navigate(route = ParcelPage(it.id)) },
-                onNavigateToSettings = { navController.navigate(route = SettingsPage) },
+      LaunchedEffect(parcelWithStatus) {
+        if (dbParcel != null && !dbParcel.isArchived) {
+          fun apiParcelError(description: String, status: Status): APIParcel {
+            return APIParcel(
+                dbParcel.parcelId,
+                listOf(ParcelHistoryItem(description, LocalDateTime.now(), "")),
+                status,
             )
-        }
+          }
 
-        composable<SettingsPage> { SettingsView(onBackPressed = { navController.popBackStack() }) }
+          launch(Dispatchers.IO) {
+            try {
+              apiParcel =
+                  context.getParcel(
+                      dbParcel.parcelId,
+                      dbParcel.postalCode,
+                      dbParcel.service,
+                  )
 
-        composable<ParcelPage> { backStackEntry ->
-            val route: ParcelPage = backStackEntry.toRoute()
-            val parcelWithStatus: ParcelWithStatus? =
-                if (demoMode) demoModeParcels[route.parcelDbId]
-                else db.parcelDao().getWithStatusById(route.parcelDbId).collectAsState(null).value
-            val dbHistory: List<dev.itsvic.parceltracker.db.ParcelHistoryItem> by
-                db.parcelHistoryDao().getAllById(route.parcelDbId).collectAsState(listOf())
-            var apiParcel: APIParcel? by remember { mutableStateOf(null) }
-            val networkFailureDetail = stringResource(R.string.network_failure_detail)
-            val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
-            val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
-            val jsonConversionError = stringResource(R.string.error_json_conversion)
-            val unexpectedErrorDetail = stringResource(R.string.error_unexpected_detail)
-
-            val dbParcel = parcelWithStatus?.parcel
-
-            LaunchedEffect(parcelWithStatus) {
-                if (dbParcel != null && !dbParcel.isArchived) {
-                    fun apiParcelError(description: String, status: Status): APIParcel {
-                        return APIParcel(
-                            dbParcel.parcelId,
-                            listOf(ParcelHistoryItem(description, LocalDateTime.now(), "")),
-                            status,
-                        )
-                    }
-
-                    launch(Dispatchers.IO) {
-                        try {
-                            apiParcel =
-                                context.getParcel(
-                                    dbParcel.parcelId,
-                                    dbParcel.postalCode,
-                                    dbParcel.service,
-                                )
-
-                            if (!demoMode) {
-                                // update parcel status
-                                val zone = ZoneId.systemDefault()
-                                val lastChange =
-                                    apiParcel!!.history.first().time.atZone(zone).toInstant()
-                                val status =
-                                    ParcelStatus(dbParcel.id, apiParcel!!.currentStatus, lastChange)
-                                if (parcelWithStatus.status == null) {
-                                    db.parcelStatusDao().insert(status)
-                                } else {
-                                    db.parcelStatusDao().update(status)
-                                }
-                            }
-                        } catch (e: IOException) {
-                            Log.w("MainActivity", "Failed fetch: $e")
-                            apiParcel = apiParcelError(networkFailureDetail, Status.NetworkFailure)
-                        } catch (_: ParcelNonExistentException) {
-                            apiParcel = apiParcelError(parcelDoesntExistDetail, Status.NoData)
-                        } catch (_: APIKeyMissingException) {
-                            apiParcel = apiParcelError(noApiKeyProvided, Status.NetworkFailure)
-                        } catch (e: JsonDataException) {
-                            Log.w(
-                                "MainActivity",
-                                "Unexpected JSON response that could not be converted: ${e.message}",
-                            )
-                            apiParcel =
-                                apiParcelError(
-                                    jsonConversionError.format(e.message),
-                                    Status.NetworkFailure,
-                                )
-                        } catch (e: Exception) {
-                            // catchall to avoid crashes
-                            Log.e("MainActivity", "Unexpected error", e)
-                            apiParcel =
-                                apiParcelError(
-                                    unexpectedErrorDetail.format(e.message),
-                                    Status.NetworkFailure,
-                                )
-                        }
-                    }
+              if (!demoMode) {
+                // update parcel status
+                val zone = ZoneId.systemDefault()
+                val lastChange = apiParcel!!.history.first().time.atZone(zone).toInstant()
+                val status = ParcelStatus(dbParcel.id, apiParcel!!.currentStatus, lastChange)
+                if (parcelWithStatus.status == null) {
+                  db.parcelStatusDao().insert(status)
+                } else {
+                  db.parcelStatusDao().update(status)
                 }
+              }
+            } catch (e: IOException) {
+              Log.w("MainActivity", "Failed fetch: $e")
+              apiParcel = apiParcelError(networkFailureDetail, Status.NetworkFailure)
+            } catch (_: ParcelNonExistentException) {
+              apiParcel = apiParcelError(parcelDoesntExistDetail, Status.NoData)
+            } catch (_: APIKeyMissingException) {
+              apiParcel = apiParcelError(noApiKeyProvided, Status.NetworkFailure)
+            } catch (e: JsonDataException) {
+              Log.w(
+                  "MainActivity",
+                  "Unexpected JSON response that could not be converted: ${e.message}",
+              )
+              apiParcel =
+                  apiParcelError(
+                      jsonConversionError.format(e.message),
+                      Status.NetworkFailure,
+                  )
+            } catch (e: Exception) {
+              // catchall to avoid crashes
+              Log.e("MainActivity", "Unexpected error", e)
+              apiParcel =
+                  apiParcelError(
+                      unexpectedErrorDetail.format(e.message),
+                      Status.NetworkFailure,
+                  )
+            }
+          }
+        }
+      }
+
+      val fakeApiParcel =
+          parcelWithStatus?.let {
+            APIParcel(
+                id = it.parcel.parcelId,
+                currentStatus = if (it.status != null) it.status.status else Status.Unknown,
+                history =
+                    dbHistory.map { item ->
+                      ParcelHistoryItem(item.description, item.time, item.location)
+                    },
+            )
+          }
+
+      if (apiParcel == null && dbParcel?.isArchived == false || dbParcel == null)
+          Box(
+              modifier =
+                  Modifier.background(color = MaterialTheme.colorScheme.background).fillMaxSize(),
+              contentAlignment = Alignment.Center,
+          ) {
+            CircularProgressIndicator()
+          }
+      else
+          ParcelView(
+              if (dbParcel.isArchived) fakeApiParcel!! else apiParcel!!,
+              dbParcel.humanName,
+              dbParcel.service,
+              dbParcel.isArchived,
+              dbParcel.archivePromptDismissed,
+              onBackPressed = { navController.popBackStack() },
+              onEdit = { navController.navigate(EditParcelPage(dbParcel.id)) },
+              onDelete = {
+                if (demoMode) {
+                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                  return@ParcelView
+                }
+
+                scope.launch(Dispatchers.IO) {
+                  deleteParcel(dbParcel)
+                  scope.launch { navController.popBackStack(HomePage, false) }
+                }
+              },
+              onArchive = {
+                if (dbParcel.isArchived) return@ParcelView
+                if (demoMode) {
+                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                  return@ParcelView
+                }
+                scope.launch(Dispatchers.IO) {
+                  db.parcelDao().update(dbParcel.copy(isArchived = true))
+                  db.parcelHistoryDao()
+                      .insert(
+                          apiParcel!!.history.map {
+                            dev.itsvic.parceltracker.db.ParcelHistoryItem(
+                                description = it.description,
+                                location = it.location,
+                                time = it.time,
+                                parcelId = dbParcel.id,
+                            )
+                          })
+                }
+              },
+              onArchivePromptDismissal = {
+                if (demoMode) {
+                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                  return@ParcelView
+                }
+                scope.launch(Dispatchers.IO) {
+                  db.parcelDao().update(dbParcel.copy(archivePromptDismissed = true))
+                }
+              },
+          )
+    }
+
+    composable<AddParcelPage> { backStackEntry ->
+      val route: AddParcelPage = backStackEntry.toRoute()
+      AddEditParcelView(
+          null,
+          prefillService = route.prefillService ?: Service.UNDEFINED,
+          prefillTrackingId = route.prefillTrackingId ?: "",
+          prefillPostalCode = route.prefillPostalCode ?: "",
+          onBackPressed = { navController.popBackStack() },
+          onCompleted = {
+            if (demoMode) {
+              Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+              return@AddEditParcelView
             }
 
-            val fakeApiParcel =
-                parcelWithStatus?.let {
-                    APIParcel(
-                        id = it.parcel.parcelId,
-                        currentStatus = if (it.status != null) it.status.status else Status.Unknown,
-                        history =
-                            dbHistory.map { item ->
-                                ParcelHistoryItem(item.description, item.time, item.location)
-                            },
-                    )
-                }
-
-            if (apiParcel == null && dbParcel?.isArchived == false || dbParcel == null)
-                Box(
-                    modifier =
-                        Modifier.background(color = MaterialTheme.colorScheme.background)
-                            .fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
-                }
-            else
-                ParcelView(
-                    if (dbParcel.isArchived) fakeApiParcel!! else apiParcel!!,
-                    dbParcel.humanName,
-                    dbParcel.service,
-                    dbParcel.isArchived,
-                    dbParcel.archivePromptDismissed,
-                    onBackPressed = { navController.popBackStack() },
-                    onEdit = { navController.navigate(EditParcelPage(dbParcel.id)) },
-                    onDelete = {
-                        if (demoMode) {
-                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                            return@ParcelView
-                        }
-
-                        scope.launch(Dispatchers.IO) {
-                            deleteParcel(dbParcel)
-                            scope.launch { navController.popBackStack(HomePage, false) }
-                        }
-                    },
-                    onArchive = {
-                        if (dbParcel.isArchived) return@ParcelView
-                        if (demoMode) {
-                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                            return@ParcelView
-                        }
-                        scope.launch(Dispatchers.IO) {
-                            db.parcelDao().update(dbParcel.copy(isArchived = true))
-                            db.parcelHistoryDao()
-                                .insert(
-                                    apiParcel!!.history.map {
-                                        dev.itsvic.parceltracker.db.ParcelHistoryItem(
-                                            description = it.description,
-                                            location = it.location,
-                                            time = it.time,
-                                            parcelId = dbParcel.id,
-                                        )
-                                    }
-                                )
-                        }
-                    },
-                    onArchivePromptDismissal = {
-                        if (demoMode) {
-                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                            return@ParcelView
-                        }
-                        scope.launch(Dispatchers.IO) {
-                            db.parcelDao().update(dbParcel.copy(archivePromptDismissed = true))
-                        }
-                    },
-                )
-        }
-
-        composable<AddParcelPage> { backStackEntry ->
-            val route: AddParcelPage = backStackEntry.toRoute()
-            AddEditParcelView(
-                null,
-                prefillService = route.prefillService ?: Service.UNDEFINED,
-                prefillTrackingId = route.prefillTrackingId ?: "",
-                prefillPostalCode = route.prefillPostalCode ?: "",
-                onBackPressed = { navController.popBackStack() },
-                onCompleted = {
-                    if (demoMode) {
-                        Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                        return@AddEditParcelView
-                    }
-
-                    scope.launch(Dispatchers.IO) {
-                        val id = db.parcelDao().insert(it)
-                        scope.launch {
-                            navController.navigate(route = ParcelPage(id.toInt())) {
-                                popUpTo(HomePage)
-                            }
-                        }
-                    }
-                },
-            )
-        }
-
-        composable<EditParcelPage> { backStackEntry ->
-            val route: EditParcelPage = backStackEntry.toRoute()
-            val parcel: Parcel? =
-                if (demoMode) demoModeParcels[route.parcelDbId].parcel
-                else db.parcelDao().getById(route.parcelDbId).collectAsState(null).value
-
-            if (parcel == null)
-                return@composable Box(
-                    modifier =
-                        Modifier.background(color = MaterialTheme.colorScheme.background)
-                            .fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
-                }
-
-            AddEditParcelView(
-                parcel,
-                onBackPressed = { navController.popBackStack() },
-                onCompleted = {
-                    if (demoMode) {
-                        Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                        return@AddEditParcelView
-                    }
-
-                    scope.launch(Dispatchers.IO) {
-                        db.parcelDao().update(it)
-                        scope.launch { navController.popBackStack() }
-                    }
-                },
-            )
-        }
+            scope.launch(Dispatchers.IO) {
+              val id = db.parcelDao().insert(it)
+              scope.launch {
+                navController.navigate(route = ParcelPage(id.toInt())) { popUpTo(HomePage) }
+              }
+            }
+          },
+      )
     }
+
+    composable<EditParcelPage> { backStackEntry ->
+      val route: EditParcelPage = backStackEntry.toRoute()
+      val parcel: Parcel? =
+          if (demoMode) demoModeParcels[route.parcelDbId].parcel
+          else db.parcelDao().getById(route.parcelDbId).collectAsState(null).value
+
+      if (parcel == null)
+          return@composable Box(
+              modifier =
+                  Modifier.background(color = MaterialTheme.colorScheme.background).fillMaxSize(),
+              contentAlignment = Alignment.Center,
+          ) {
+            CircularProgressIndicator()
+          }
+
+      AddEditParcelView(
+          parcel,
+          onBackPressed = { navController.popBackStack() },
+          onCompleted = {
+            if (demoMode) {
+              Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+              return@AddEditParcelView
+            }
+
+            scope.launch(Dispatchers.IO) {
+              db.parcelDao().update(it)
+              scope.launch { navController.popBackStack() }
+            }
+          },
+      )
+    }
+  }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -50,8 +51,11 @@ import dev.itsvic.parceltracker.api.APIKeyMissingException
 import dev.itsvic.parceltracker.api.Parcel as APIParcel
 import dev.itsvic.parceltracker.api.ParcelHistoryItem
 import dev.itsvic.parceltracker.api.ParcelNonExistentException
+import dev.itsvic.parceltracker.api.Service
 import dev.itsvic.parceltracker.api.Status
 import dev.itsvic.parceltracker.api.getParcel
+import dev.itsvic.parceltracker.api.parseSharedText
+import dev.itsvic.parceltracker.api.parseTrackingUrl
 import dev.itsvic.parceltracker.db.Parcel
 import dev.itsvic.parceltracker.db.ParcelStatus
 import dev.itsvic.parceltracker.db.ParcelWithStatus
@@ -70,61 +74,92 @@ import kotlinx.serialization.Serializable
 import okio.IOException
 
 class MainActivity : ComponentActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    installSplashScreen()
-    super.onCreate(savedInstanceState)
-    enableEdgeToEdge()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) handleNotificationPermissionStuff()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            handleNotificationPermissionStuff()
 
-    parcelToOpen = mutableIntStateOf(intent.getIntExtra("openParcel", -1))
+        parcelToOpen = mutableIntStateOf(intent.getIntExtra("openParcel", -1))
+        addParcelIntent = mutableStateOf(resolveAddParcelIntent(intent))
 
-    setContent {
-      val parcelToOpen by parcelToOpen
+        setContent {
+            val parcelToOpen by parcelToOpen
+            val addParcelIntent by addParcelIntent
 
-      ParcelTrackerTheme {
-        Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.background)) {
-          ParcelAppNavigation(parcelToOpen)
+            ParcelTrackerTheme {
+                Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.background)) {
+                    ParcelAppNavigation(parcelToOpen, addParcelIntent)
+                }
+            }
         }
-      }
     }
-  }
 
-  companion object {
-    lateinit var parcelToOpen: MutableIntState
-  }
+    companion object {
+        lateinit var parcelToOpen: MutableIntState
+        lateinit var addParcelIntent: MutableState<AddParcelPage?>
 
-  override fun onNewIntent(intent: Intent) {
-    super.onNewIntent(intent)
-    parcelToOpen.intValue = intent.getIntExtra("openParcel", -1)
-  }
-
-  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-  fun handleNotificationPermissionStuff() {
-    val requestPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean
-          ->
-          if (isGranted) {
-            Log.d("MainActivity", "Notification permissions granted")
-          } else {
-            Log.d("MainActivity", "Notification permissions NOT granted")
-          }
+        // Resolves a share (ACTION_SEND) or deep link (ACTION_VIEW) intent into
+        // an AddParcelPage prefill, if any. Returns null for intents that aren't
+        // asking to add a parcel at all (e.g. the initial MAIN/LAUNCHER intent).
+        private fun resolveAddParcelIntent(intent: Intent): AddParcelPage? {
+            return when (intent.action) {
+                Intent.ACTION_SEND -> {
+                    if (intent.type != "text/plain") null
+                    else {
+                        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                        val match = text?.let { parseSharedText(it) }
+                        AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
+                    }
+                }
+                Intent.ACTION_VIEW -> {
+                    val data = intent.data
+                    if (data == null) null
+                    else {
+                        val match = parseTrackingUrl(data.toString())
+                        AddParcelPage(match?.service, match?.trackingId, match?.postalCode)
+                    }
+                }
+                else -> null
+            }
         }
-
-    // Notification checks
-    when {
-      ContextCompat.checkSelfPermission(
-          applicationContext,
-          Manifest.permission.POST_NOTIFICATIONS,
-      ) == PackageManager.PERMISSION_GRANTED -> {
-        // We can post notifications
-      }
-      // TODO: educational UI maybe?
-      else -> {
-        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-      }
     }
-  }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        parcelToOpen.intValue = intent.getIntExtra("openParcel", -1)
+        resolveAddParcelIntent(intent)?.let { addParcelIntent.value = it }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    fun handleNotificationPermissionStuff() {
+        val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+                isGranted: Boolean ->
+                if (isGranted) {
+                    Log.d("MainActivity", "Notification permissions granted")
+                } else {
+                    Log.d("MainActivity", "Notification permissions NOT granted")
+                }
+            }
+
+        // Notification checks
+        when {
+            ContextCompat.checkSelfPermission(
+                applicationContext,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                // We can post notifications
+            }
+            // TODO: educational UI maybe?
+            else -> {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
 }
 
 @Serializable object HomePage
@@ -133,249 +168,284 @@ class MainActivity : ComponentActivity() {
 
 @Serializable data class ParcelPage(val parcelDbId: Int)
 
-@Serializable object AddParcelPage
+@Serializable
+data class AddParcelPage(
+    val prefillService: Service? = null,
+    val prefillTrackingId: String? = null,
+    val prefillPostalCode: String? = null,
+)
 
 @Serializable data class EditParcelPage(val parcelDbId: Int)
 
 @Composable
-fun ParcelAppNavigation(parcelToOpen: Int) {
-  val db = ParcelApplication.db
-  val navController = rememberNavController()
-  val scope = rememberCoroutineScope()
-  val context = LocalContext.current
-  val preferences by context.dataStore.data.collectAsState(emptyPreferences())
-  val demoMode = preferences[DEMO_MODE] == true
-  val demoModeActionBlock = stringResource(R.string.demo_mode_action_block)
+fun ParcelAppNavigation(parcelToOpen: Int, addParcelIntent: AddParcelPage?) {
+    val db = ParcelApplication.db
+    val navController = rememberNavController()
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val preferences by context.dataStore.data.collectAsState(emptyPreferences())
+    val demoMode = preferences[DEMO_MODE] == true
+    val demoModeActionBlock = stringResource(R.string.demo_mode_action_block)
 
-  LaunchedEffect(parcelToOpen) {
-    if (parcelToOpen != -1) {
-      navController.navigate(route = ParcelPage(parcelToOpen)) { popUpTo(HomePage) }
-    }
-  }
-
-  val animDuration = 300
-
-  NavHost(
-      navController = navController,
-      startDestination = HomePage,
-      enterTransition = {
-        slideIntoContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Start,
-            animationSpec = tween(animDuration),
-            initialOffset = { it / 4 }) + fadeIn(tween(animDuration))
-      },
-      exitTransition = { fadeOut(tween(animDuration)) + scaleOut(tween(500), 0.9f) },
-      popEnterTransition = { fadeIn(tween(animDuration)) + scaleIn(tween(500), 0.9f) },
-      popExitTransition = {
-        slideOutOfContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Start,
-            animationSpec = tween(animDuration),
-            targetOffset = { -it / 4 }) + fadeOut(tween(animDuration))
-      },
-  ) {
-    composable<HomePage> {
-      val parcels =
-          if (demoMode) demoModeParcels
-          else db.parcelDao().getAllWithStatus().collectAsState(initial = emptyList()).value
-
-      HomeView(
-          parcels = parcels,
-          onNavigateToAddParcel = { navController.navigate(route = AddParcelPage) },
-          onNavigateToParcel = { navController.navigate(route = ParcelPage(it.id)) },
-          onNavigateToSettings = { navController.navigate(route = SettingsPage) },
-      )
-    }
-
-    composable<SettingsPage> { SettingsView(onBackPressed = { navController.popBackStack() }) }
-
-    composable<ParcelPage> { backStackEntry ->
-      val route: ParcelPage = backStackEntry.toRoute()
-      val parcelWithStatus: ParcelWithStatus? =
-          if (demoMode) demoModeParcels[route.parcelDbId]
-          else db.parcelDao().getWithStatusById(route.parcelDbId).collectAsState(null).value
-      val dbHistory: List<dev.itsvic.parceltracker.db.ParcelHistoryItem> by
-          db.parcelHistoryDao().getAllById(route.parcelDbId).collectAsState(listOf())
-      var apiParcel: APIParcel? by remember { mutableStateOf(null) }
-      val networkFailureDetail = stringResource(R.string.network_failure_detail)
-      val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
-      val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
-      val jsonConversionError = stringResource(R.string.error_json_conversion)
-      val unexpectedErrorDetail = stringResource(R.string.error_unexpected_detail)
-
-      val dbParcel = parcelWithStatus?.parcel
-
-      LaunchedEffect(parcelWithStatus) {
-        if (dbParcel != null && !dbParcel.isArchived) {
-          fun apiParcelError(description: String, status: Status): APIParcel {
-            return APIParcel(
-                dbParcel.parcelId,
-                listOf(ParcelHistoryItem(description, LocalDateTime.now(), "")),
-                status)
-          }
-
-          launch(Dispatchers.IO) {
-            try {
-              apiParcel =
-                  context.getParcel(dbParcel.parcelId, dbParcel.postalCode, dbParcel.service)
-
-              if (!demoMode) {
-                // update parcel status
-                val zone = ZoneId.systemDefault()
-                val lastChange = apiParcel!!.history.first().time.atZone(zone).toInstant()
-                val status =
-                    ParcelStatus(
-                        dbParcel.id,
-                        apiParcel!!.currentStatus,
-                        lastChange,
-                    )
-                if (parcelWithStatus.status == null) {
-                  db.parcelStatusDao().insert(status)
-                } else {
-                  db.parcelStatusDao().update(status)
-                }
-              }
-            } catch (e: IOException) {
-              Log.w("MainActivity", "Failed fetch: $e")
-              apiParcel = apiParcelError(networkFailureDetail, Status.NetworkFailure)
-            } catch (_: ParcelNonExistentException) {
-              apiParcel = apiParcelError(parcelDoesntExistDetail, Status.NoData)
-            } catch (_: APIKeyMissingException) {
-              apiParcel = apiParcelError(noApiKeyProvided, Status.NetworkFailure)
-            } catch (e: JsonDataException) {
-              Log.w(
-                  "MainActivity",
-                  "Unexpected JSON response that could not be converted: ${e.message}")
-              apiParcel =
-                  apiParcelError(jsonConversionError.format(e.message), Status.NetworkFailure)
-            } catch (e: Exception) {
-              // catchall to avoid crashes
-              Log.e("MainActivity", "Unexpected error", e)
-              apiParcel =
-                  apiParcelError(unexpectedErrorDetail.format(e.message), Status.NetworkFailure)
-            }
-          }
+    LaunchedEffect(parcelToOpen) {
+        if (parcelToOpen != -1) {
+            navController.navigate(route = ParcelPage(parcelToOpen)) { popUpTo(HomePage) }
         }
-      }
+    }
 
-      val fakeApiParcel =
-          parcelWithStatus?.let {
-            APIParcel(
-                id = it.parcel.parcelId,
-                currentStatus = if (it.status != null) it.status.status else Status.Unknown,
-                history =
-                    dbHistory.map { item ->
-                      ParcelHistoryItem(item.description, item.time, item.location)
-                    })
-          }
+    LaunchedEffect(addParcelIntent) {
+        if (addParcelIntent != null) {
+            navController.navigate(route = addParcelIntent) { popUpTo(HomePage) }
+            MainActivity.addParcelIntent.value = null
+        }
+    }
 
-      if (apiParcel == null && dbParcel?.isArchived == false || dbParcel == null)
-          Box(
-              modifier =
-                  Modifier.background(color = MaterialTheme.colorScheme.background).fillMaxSize(),
-              contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-              }
-      else
-          ParcelView(
-              if (dbParcel.isArchived) fakeApiParcel!! else apiParcel!!,
-              dbParcel.humanName,
-              dbParcel.service,
-              dbParcel.isArchived,
-              dbParcel.archivePromptDismissed,
-              onBackPressed = { navController.popBackStack() },
-              onEdit = { navController.navigate(EditParcelPage(dbParcel.id)) },
-              onDelete = {
-                if (demoMode) {
-                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                  return@ParcelView
-                }
+    val animDuration = 300
 
-                scope.launch(Dispatchers.IO) {
-                  deleteParcel(dbParcel)
-                  scope.launch { navController.popBackStack(HomePage, false) }
-                }
-              },
-              onArchive = {
-                if (dbParcel.isArchived) return@ParcelView
-                if (demoMode) {
-                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                  return@ParcelView
-                }
-                scope.launch(Dispatchers.IO) {
-                  db.parcelDao().update(dbParcel.copy(isArchived = true))
-                  db.parcelHistoryDao()
-                      .insert(
-                          apiParcel!!.history.map {
-                            dev.itsvic.parceltracker.db.ParcelHistoryItem(
-                                description = it.description,
-                                location = it.location,
-                                time = it.time,
-                                parcelId = dbParcel.id,
+    NavHost(
+        navController = navController,
+        startDestination = HomePage,
+        enterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(animDuration),
+                initialOffset = { it / 4 },
+            ) + fadeIn(tween(animDuration))
+        },
+        exitTransition = { fadeOut(tween(animDuration)) + scaleOut(tween(500), 0.9f) },
+        popEnterTransition = { fadeIn(tween(animDuration)) + scaleIn(tween(500), 0.9f) },
+        popExitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(animDuration),
+                targetOffset = { -it / 4 },
+            ) + fadeOut(tween(animDuration))
+        },
+    ) {
+        composable<HomePage> {
+            val parcels =
+                if (demoMode) demoModeParcels
+                else db.parcelDao().getAllWithStatus().collectAsState(initial = emptyList()).value
+
+            HomeView(
+                parcels = parcels,
+                onNavigateToAddParcel = { navController.navigate(route = AddParcelPage()) },
+                onNavigateToParcel = { navController.navigate(route = ParcelPage(it.id)) },
+                onNavigateToSettings = { navController.navigate(route = SettingsPage) },
+            )
+        }
+
+        composable<SettingsPage> { SettingsView(onBackPressed = { navController.popBackStack() }) }
+
+        composable<ParcelPage> { backStackEntry ->
+            val route: ParcelPage = backStackEntry.toRoute()
+            val parcelWithStatus: ParcelWithStatus? =
+                if (demoMode) demoModeParcels[route.parcelDbId]
+                else db.parcelDao().getWithStatusById(route.parcelDbId).collectAsState(null).value
+            val dbHistory: List<dev.itsvic.parceltracker.db.ParcelHistoryItem> by
+                db.parcelHistoryDao().getAllById(route.parcelDbId).collectAsState(listOf())
+            var apiParcel: APIParcel? by remember { mutableStateOf(null) }
+            val networkFailureDetail = stringResource(R.string.network_failure_detail)
+            val parcelDoesntExistDetail = stringResource(R.string.parcel_doesnt_exist_detail)
+            val noApiKeyProvided = stringResource(R.string.error_no_api_key_provided)
+            val jsonConversionError = stringResource(R.string.error_json_conversion)
+            val unexpectedErrorDetail = stringResource(R.string.error_unexpected_detail)
+
+            val dbParcel = parcelWithStatus?.parcel
+
+            LaunchedEffect(parcelWithStatus) {
+                if (dbParcel != null && !dbParcel.isArchived) {
+                    fun apiParcelError(description: String, status: Status): APIParcel {
+                        return APIParcel(
+                            dbParcel.parcelId,
+                            listOf(ParcelHistoryItem(description, LocalDateTime.now(), "")),
+                            status,
+                        )
+                    }
+
+                    launch(Dispatchers.IO) {
+                        try {
+                            apiParcel =
+                                context.getParcel(
+                                    dbParcel.parcelId,
+                                    dbParcel.postalCode,
+                                    dbParcel.service,
+                                )
+
+                            if (!demoMode) {
+                                // update parcel status
+                                val zone = ZoneId.systemDefault()
+                                val lastChange =
+                                    apiParcel!!.history.first().time.atZone(zone).toInstant()
+                                val status =
+                                    ParcelStatus(dbParcel.id, apiParcel!!.currentStatus, lastChange)
+                                if (parcelWithStatus.status == null) {
+                                    db.parcelStatusDao().insert(status)
+                                } else {
+                                    db.parcelStatusDao().update(status)
+                                }
+                            }
+                        } catch (e: IOException) {
+                            Log.w("MainActivity", "Failed fetch: $e")
+                            apiParcel = apiParcelError(networkFailureDetail, Status.NetworkFailure)
+                        } catch (_: ParcelNonExistentException) {
+                            apiParcel = apiParcelError(parcelDoesntExistDetail, Status.NoData)
+                        } catch (_: APIKeyMissingException) {
+                            apiParcel = apiParcelError(noApiKeyProvided, Status.NetworkFailure)
+                        } catch (e: JsonDataException) {
+                            Log.w(
+                                "MainActivity",
+                                "Unexpected JSON response that could not be converted: ${e.message}",
                             )
-                          })
+                            apiParcel =
+                                apiParcelError(
+                                    jsonConversionError.format(e.message),
+                                    Status.NetworkFailure,
+                                )
+                        } catch (e: Exception) {
+                            // catchall to avoid crashes
+                            Log.e("MainActivity", "Unexpected error", e)
+                            apiParcel =
+                                apiParcelError(
+                                    unexpectedErrorDetail.format(e.message),
+                                    Status.NetworkFailure,
+                                )
+                        }
+                    }
                 }
-              },
-              onArchivePromptDismissal = {
-                if (demoMode) {
-                  Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-                  return@ParcelView
+            }
+
+            val fakeApiParcel =
+                parcelWithStatus?.let {
+                    APIParcel(
+                        id = it.parcel.parcelId,
+                        currentStatus = if (it.status != null) it.status.status else Status.Unknown,
+                        history =
+                            dbHistory.map { item ->
+                                ParcelHistoryItem(item.description, item.time, item.location)
+                            },
+                    )
                 }
-                scope.launch(Dispatchers.IO) {
-                  db.parcelDao().update(dbParcel.copy(archivePromptDismissed = true))
+
+            if (apiParcel == null && dbParcel?.isArchived == false || dbParcel == null)
+                Box(
+                    modifier =
+                        Modifier.background(color = MaterialTheme.colorScheme.background)
+                            .fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
                 }
-              },
-          )
+            else
+                ParcelView(
+                    if (dbParcel.isArchived) fakeApiParcel!! else apiParcel!!,
+                    dbParcel.humanName,
+                    dbParcel.service,
+                    dbParcel.isArchived,
+                    dbParcel.archivePromptDismissed,
+                    onBackPressed = { navController.popBackStack() },
+                    onEdit = { navController.navigate(EditParcelPage(dbParcel.id)) },
+                    onDelete = {
+                        if (demoMode) {
+                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                            return@ParcelView
+                        }
+
+                        scope.launch(Dispatchers.IO) {
+                            deleteParcel(dbParcel)
+                            scope.launch { navController.popBackStack(HomePage, false) }
+                        }
+                    },
+                    onArchive = {
+                        if (dbParcel.isArchived) return@ParcelView
+                        if (demoMode) {
+                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                            return@ParcelView
+                        }
+                        scope.launch(Dispatchers.IO) {
+                            db.parcelDao().update(dbParcel.copy(isArchived = true))
+                            db.parcelHistoryDao()
+                                .insert(
+                                    apiParcel!!.history.map {
+                                        dev.itsvic.parceltracker.db.ParcelHistoryItem(
+                                            description = it.description,
+                                            location = it.location,
+                                            time = it.time,
+                                            parcelId = dbParcel.id,
+                                        )
+                                    }
+                                )
+                        }
+                    },
+                    onArchivePromptDismissal = {
+                        if (demoMode) {
+                            Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                            return@ParcelView
+                        }
+                        scope.launch(Dispatchers.IO) {
+                            db.parcelDao().update(dbParcel.copy(archivePromptDismissed = true))
+                        }
+                    },
+                )
+        }
+
+        composable<AddParcelPage> { backStackEntry ->
+            val route: AddParcelPage = backStackEntry.toRoute()
+            AddEditParcelView(
+                null,
+                prefillService = route.prefillService ?: Service.UNDEFINED,
+                prefillTrackingId = route.prefillTrackingId ?: "",
+                prefillPostalCode = route.prefillPostalCode ?: "",
+                onBackPressed = { navController.popBackStack() },
+                onCompleted = {
+                    if (demoMode) {
+                        Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                        return@AddEditParcelView
+                    }
+
+                    scope.launch(Dispatchers.IO) {
+                        val id = db.parcelDao().insert(it)
+                        scope.launch {
+                            navController.navigate(route = ParcelPage(id.toInt())) {
+                                popUpTo(HomePage)
+                            }
+                        }
+                    }
+                },
+            )
+        }
+
+        composable<EditParcelPage> { backStackEntry ->
+            val route: EditParcelPage = backStackEntry.toRoute()
+            val parcel: Parcel? =
+                if (demoMode) demoModeParcels[route.parcelDbId].parcel
+                else db.parcelDao().getById(route.parcelDbId).collectAsState(null).value
+
+            if (parcel == null)
+                return@composable Box(
+                    modifier =
+                        Modifier.background(color = MaterialTheme.colorScheme.background)
+                            .fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+
+            AddEditParcelView(
+                parcel,
+                onBackPressed = { navController.popBackStack() },
+                onCompleted = {
+                    if (demoMode) {
+                        Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
+                        return@AddEditParcelView
+                    }
+
+                    scope.launch(Dispatchers.IO) {
+                        db.parcelDao().update(it)
+                        scope.launch { navController.popBackStack() }
+                    }
+                },
+            )
+        }
     }
-
-    composable<AddParcelPage> {
-      AddEditParcelView(
-          null,
-          onBackPressed = { navController.popBackStack() },
-          onCompleted = {
-            if (demoMode) {
-              Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-              return@AddEditParcelView
-            }
-
-            scope.launch(Dispatchers.IO) {
-              val id = db.parcelDao().insert(it)
-              scope.launch {
-                navController.navigate(route = ParcelPage(id.toInt())) { popUpTo(HomePage) }
-              }
-            }
-          },
-      )
-    }
-
-    composable<EditParcelPage> { backStackEntry ->
-      val route: EditParcelPage = backStackEntry.toRoute()
-      val parcel: Parcel? =
-          if (demoMode) demoModeParcels[route.parcelDbId].parcel
-          else db.parcelDao().getById(route.parcelDbId).collectAsState(null).value
-
-      if (parcel == null)
-          return@composable Box(
-              modifier =
-                  Modifier.background(color = MaterialTheme.colorScheme.background).fillMaxSize(),
-              contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-              }
-
-      AddEditParcelView(
-          parcel,
-          onBackPressed = { navController.popBackStack() },
-          onCompleted = {
-            if (demoMode) {
-              Toast.makeText(context, demoModeActionBlock, Toast.LENGTH_SHORT).show()
-              return@AddEditParcelView
-            }
-
-            scope.launch(Dispatchers.IO) {
-              db.parcelDao().update(it)
-              scope.launch { navController.popBackStack() }
-            }
-          },
-      )
-    }
-  }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -17,99 +17,99 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 
 @Serializable
 enum class Service {
-    UNDEFINED,
-    EXAMPLE,
+  UNDEFINED,
+  EXAMPLE,
 
-    // International
-    CAINIAO,
-    DHL,
-    GLS,
-    UPS,
-    FPX,
+  // International
+  CAINIAO,
+  DHL,
+  GLS,
+  UPS,
+  FPX,
 
-    // North America
-    UNIUNI,
+  // North America
+  UNIUNI,
 
-    // United Kingdom
-    DPD_UK,
-    EVRI,
+  // United Kingdom
+  DPD_UK,
+  EVRI,
 
-    // Europe
-    AN_POST,
-    BELPOST,
-    DPD_GER,
-    DPD_PL,
-    GLS_HUNGARY,
-    HERMES,
-    MAGYAR_POSTA,
-    NOVA_POSHTA,
-    PACKETA,
-    POLISH_POST,
-    POSTE_ITALIANE,
-    POST_NL,
-    SAMEDAY_BG,
-    SAMEDAY_HU,
-    SAMEDAY_RO,
-    UKRPOSHTA,
-    POSTNORD,
-    ALLEGRO_ONEBOX,
-    INPOST,
-    INPOST_IT,
-    ORLEN_PACZKA,
+  // Europe
+  AN_POST,
+  BELPOST,
+  DPD_GER,
+  DPD_PL,
+  GLS_HUNGARY,
+  HERMES,
+  MAGYAR_POSTA,
+  NOVA_POSHTA,
+  PACKETA,
+  POLISH_POST,
+  POSTE_ITALIANE,
+  POST_NL,
+  SAMEDAY_BG,
+  SAMEDAY_HU,
+  SAMEDAY_RO,
+  UKRPOSHTA,
+  POSTNORD,
+  ALLEGRO_ONEBOX,
+  INPOST,
+  INPOST_IT,
+  ORLEN_PACZKA,
 
-    // Asia
-    EKART,
-    SPX_TH,
+  // Asia
+  EKART,
+  SPX_TH,
 }
 
 val serviceOptions =
     Service.entries
         .filter {
-            return@filter it != Service.UNDEFINED && it != Service.EXAMPLE
+          return@filter it != Service.UNDEFINED && it != Service.EXAMPLE
         }
         .toList()
 
 fun getDeliveryService(service: Service): DeliveryService? {
-    return when (service) {
-        Service.CAINIAO -> CainiaoDeliveryService
-        Service.DHL -> DhlDeliveryService
-        Service.GLS -> GLSGlobalDeliveryService
-        Service.UPS -> UPSDeliveryService
-        Service.FPX -> FPXDeliveryService
+  return when (service) {
+    Service.CAINIAO -> CainiaoDeliveryService
+    Service.DHL -> DhlDeliveryService
+    Service.GLS -> GLSGlobalDeliveryService
+    Service.UPS -> UPSDeliveryService
+    Service.FPX -> FPXDeliveryService
 
-        Service.UNIUNI -> UniUniDeliveryService
+    Service.UNIUNI -> UniUniDeliveryService
 
-        Service.DPD_UK -> DpdUkDeliveryService
-        Service.EVRI -> EvriDeliveryService
+    Service.DPD_UK -> DpdUkDeliveryService
+    Service.EVRI -> EvriDeliveryService
 
-        Service.AN_POST -> AnPostDeliveryService
-        Service.BELPOST -> BelpostDeliveryService
-        Service.DPD_GER -> DpdGerDeliveryService
-        Service.DPD_PL -> DpdPlDeliveryService
-        Service.GLS_HUNGARY -> GLSHungaryDeliveryService
-        Service.HERMES -> HermesDeliveryService
-        Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
-        Service.NOVA_POSHTA -> NovaPostDeliveryService
-        Service.PACKETA -> PacketaDeliveryService
-        Service.POLISH_POST -> PolishPostDeliveryService
-        Service.POSTE_ITALIANE -> PosteItalianeDeliveryService
-        Service.POST_NL -> PostNLDeliveryService
-        Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
-        Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
-        Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
-        Service.UKRPOSHTA -> UkrposhtaDeliveryService
-        Service.POSTNORD -> PostNordDeliveryService
-        Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
-        Service.INPOST -> InPostDeliveryService
-        Service.INPOST_IT -> InPostItalyDeliveryService
-        Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService
+    Service.AN_POST -> AnPostDeliveryService
+    Service.BELPOST -> BelpostDeliveryService
+    Service.DPD_GER -> DpdGerDeliveryService
+    Service.DPD_PL -> DpdPlDeliveryService
+    Service.GLS_HUNGARY -> GLSHungaryDeliveryService
+    Service.HERMES -> HermesDeliveryService
+    Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
+    Service.NOVA_POSHTA -> NovaPostDeliveryService
+    Service.PACKETA -> PacketaDeliveryService
+    Service.POLISH_POST -> PolishPostDeliveryService
+    Service.POSTE_ITALIANE -> PosteItalianeDeliveryService
+    Service.POST_NL -> PostNLDeliveryService
+    Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
+    Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
+    Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
+    Service.UKRPOSHTA -> UkrposhtaDeliveryService
+    Service.POSTNORD -> PostNordDeliveryService
+    Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
+    Service.INPOST -> InPostDeliveryService
+    Service.INPOST_IT -> InPostItalyDeliveryService
+    Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService
 
-        Service.EKART -> EKartDeliveryService
-        Service.SPX_TH -> SPXThailandDeliveryService
+    Service.EKART -> EKartDeliveryService
+    Service.SPX_TH -> SPXThailandDeliveryService
 
-        Service.EXAMPLE -> ExampleDeliveryService
-        else -> null
-    }
+    Service.EXAMPLE -> ExampleDeliveryService
+    else -> null
+  }
 }
 
 internal val api_client =
@@ -118,9 +118,7 @@ internal val api_client =
             HttpLoggingInterceptor { Log.d("OkHttp", it) }
                 .setLevel(
                     if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-                    else HttpLoggingInterceptor.Level.BASIC
-                )
-        )
+                    else HttpLoggingInterceptor.Level.BASIC))
         .build()
 
 internal val api_moshi: Moshi = Moshi.Builder().build()
@@ -141,73 +139,73 @@ data class ParcelHistoryItem(
 )
 
 enum class Status(val nameResource: Int) {
-    Preadvice(R.string.status_preadvice),
-    LockerboxAcceptedParcel(R.string.status_lockerbox_accepted_parcel),
-    PickedUpByCourier(R.string.status_picked_up_by_courier),
-    InTransit(R.string.status_in_transit),
-    Readdressed(R.string.status_readdressed),
-    InWarehouse(R.string.status_in_warehouse),
-    Customs(R.string.status_customs),
-    CustomsSuccess(R.string.status_customs_cleared),
-    CustomsHeld(R.string.status_customs_held),
-    OutForDelivery(R.string.status_out_for_delivery),
-    DeliveryFailure(R.string.status_delivery_failure),
-    Delivered(R.string.status_delivered),
-    DeliveredToNeighbor(R.string.status_delivered_to_neighbor),
-    DeliveredToASafePlace(R.string.status_delivered_to_a_safe_place),
-    DroppedAtCustomerService(R.string.status_dropped_at_cs),
-    ReturningToSender(R.string.status_returning_to_sender),
-    ReturnedToSender(R.string.status_returned_to_sender),
-    AwaitingPickup(R.string.status_awaiting_pickup),
-    PickupTimeEndingSoon(R.string.status_pickup_time_ending_soon),
-    PickedUp(R.string.status_picked_up),
-    Delayed(R.string.status_delayed),
-    Damaged(R.string.status_damaged),
-    Destroyed(R.string.status_destroyed),
-    Unknown(R.string.status_unknown),
-    NetworkFailure(R.string.status_network_failure),
-    NoData(R.string.status_no_data),
+  Preadvice(R.string.status_preadvice),
+  LockerboxAcceptedParcel(R.string.status_lockerbox_accepted_parcel),
+  PickedUpByCourier(R.string.status_picked_up_by_courier),
+  InTransit(R.string.status_in_transit),
+  Readdressed(R.string.status_readdressed),
+  InWarehouse(R.string.status_in_warehouse),
+  Customs(R.string.status_customs),
+  CustomsSuccess(R.string.status_customs_cleared),
+  CustomsHeld(R.string.status_customs_held),
+  OutForDelivery(R.string.status_out_for_delivery),
+  DeliveryFailure(R.string.status_delivery_failure),
+  Delivered(R.string.status_delivered),
+  DeliveredToNeighbor(R.string.status_delivered_to_neighbor),
+  DeliveredToASafePlace(R.string.status_delivered_to_a_safe_place),
+  DroppedAtCustomerService(R.string.status_dropped_at_cs),
+  ReturningToSender(R.string.status_returning_to_sender),
+  ReturnedToSender(R.string.status_returned_to_sender),
+  AwaitingPickup(R.string.status_awaiting_pickup),
+  PickupTimeEndingSoon(R.string.status_pickup_time_ending_soon),
+  PickedUp(R.string.status_picked_up),
+  Delayed(R.string.status_delayed),
+  Damaged(R.string.status_damaged),
+  Destroyed(R.string.status_destroyed),
+  Unknown(R.string.status_unknown),
+  NetworkFailure(R.string.status_network_failure),
+  NoData(R.string.status_no_data),
 }
 
 suspend fun Context.getParcel(id: String, postCode: String?, service: Service): Parcel {
-    // use DeliveryService abstraction if possible, otherwise default to the old hardcoded list
-    getDeliveryService(service)?.let {
-        return it.getParcel(this, id, postCode)
-    }
+  // use DeliveryService abstraction if possible, otherwise default to the old hardcoded list
+  getDeliveryService(service)?.let {
+    return it.getParcel(this, id, postCode)
+  }
 
-    throw NotImplementedError("Service $service has no DeliveryService object")
+  throw NotImplementedError("Service $service has no DeliveryService object")
 }
 
 fun getDeliveryServiceName(service: Service): Int? {
-    return getDeliveryService(service)?.nameResource
+  return getDeliveryService(service)?.nameResource
 }
 
 interface DeliveryService {
-    val nameResource: Int
-    val acceptsPostCode: Boolean
-    val requiresPostCode: Boolean
-    val requiresApiKey: Boolean
-        get() = false
+  val nameResource: Int
+  val acceptsPostCode: Boolean
+  val requiresPostCode: Boolean
+  val requiresApiKey: Boolean
+    get() = false
 
-    val apiKeyPreference: Preferences.Key<String>?
-        get() = null
+  val apiKeyPreference: Preferences.Key<String>?
+    get() = null
 
-    suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        return TODO("DeliveryService does not implement getParcel")
-    }
+  suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    return TODO("DeliveryService does not implement getParcel")
+  }
 
-    suspend fun getParcel(context: Context, trackingId: String, postalCode: String?): Parcel {
-        return getParcel(trackingId, postalCode)
-    }
+  suspend fun getParcel(context: Context, trackingId: String, postalCode: String?): Parcel {
+    return getParcel(trackingId, postalCode)
+  }
 
-    fun acceptsFormat(trackingId: String): Boolean {
-        return false
-    }
+  fun acceptsFormat(trackingId: String): Boolean {
+    return false
+  }
 
-    // List of patterns that match this provider's public tracking-page URLs.
-    // See TrackingUrlPattern for matching semantics.
-    val trackingUrlPatterns: List<TrackingUrlPattern>
-        get() = emptyList()
+  // List of patterns that match this provider's public tracking-page URLs.
+  // See TrackingUrlPattern for matching semantics.
+  val trackingUrlPatterns: List<TrackingUrlPattern>
+    get() = emptyList()
 }
 
 // A pattern matching a provider's public tracking-page URLs. urlRegex's first
@@ -223,10 +221,10 @@ class APIKeyMissingException :
     Exception("Delivery service requires an API key but none is present")
 
 internal fun logUnknownStatus(service: String, data: String): Status {
-    Log.d("APICore", "Unknown status reported by $service: $data")
-    return Status.Unknown
+  Log.d("APICore", "Unknown status reported by $service: $data")
+  return Status.Unknown
 }
 
 fun localDateFromMilli(milli: Long): LocalDateTime {
-    return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), TimeZone.getDefault().toZoneId())
+  return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), TimeZone.getDefault().toZoneId())
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -10,104 +10,106 @@ import dev.itsvic.parceltracker.R
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.TimeZone
+import kotlinx.serialization.Serializable
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.moshi.MoshiConverterFactory
 
+@Serializable
 enum class Service {
-  UNDEFINED,
-  EXAMPLE,
+    UNDEFINED,
+    EXAMPLE,
 
-  // International
-  CAINIAO,
-  DHL,
-  GLS,
-  UPS,
-  FPX,
+    // International
+    CAINIAO,
+    DHL,
+    GLS,
+    UPS,
+    FPX,
 
-  // North America
-  UNIUNI,
+    // North America
+    UNIUNI,
 
-  // United Kingdom
-  DPD_UK,
-  EVRI,
+    // United Kingdom
+    DPD_UK,
+    EVRI,
 
-  // Europe
-  AN_POST,
-  BELPOST,
-  DPD_GER,
-  DPD_PL,
-  GLS_HUNGARY,
-  HERMES,
-  MAGYAR_POSTA,
-  NOVA_POSHTA,
-  PACKETA,
-  POLISH_POST,
-  POSTE_ITALIANE,
-  POST_NL,
-  SAMEDAY_BG,
-  SAMEDAY_HU,
-  SAMEDAY_RO,
-  UKRPOSHTA,
-  POSTNORD,
-  ALLEGRO_ONEBOX,
-  INPOST,
-  INPOST_IT,
-  ORLEN_PACZKA,
+    // Europe
+    AN_POST,
+    BELPOST,
+    DPD_GER,
+    DPD_PL,
+    GLS_HUNGARY,
+    HERMES,
+    MAGYAR_POSTA,
+    NOVA_POSHTA,
+    PACKETA,
+    POLISH_POST,
+    POSTE_ITALIANE,
+    POST_NL,
+    SAMEDAY_BG,
+    SAMEDAY_HU,
+    SAMEDAY_RO,
+    UKRPOSHTA,
+    POSTNORD,
+    ALLEGRO_ONEBOX,
+    INPOST,
+    INPOST_IT,
+    ORLEN_PACZKA,
 
-  // Asia
-  EKART,
-  SPX_TH,
+    // Asia
+    EKART,
+    SPX_TH,
 }
 
 val serviceOptions =
     Service.entries
         .filter {
-          return@filter it != Service.UNDEFINED && it != Service.EXAMPLE
+            return@filter it != Service.UNDEFINED && it != Service.EXAMPLE
         }
         .toList()
 
 fun getDeliveryService(service: Service): DeliveryService? {
-  return when (service) {
-    Service.CAINIAO -> CainiaoDeliveryService
-    Service.DHL -> DhlDeliveryService
-    Service.GLS -> GLSGlobalDeliveryService
-    Service.UPS -> UPSDeliveryService
-    Service.FPX -> FPXDeliveryService
+    return when (service) {
+        Service.CAINIAO -> CainiaoDeliveryService
+        Service.DHL -> DhlDeliveryService
+        Service.GLS -> GLSGlobalDeliveryService
+        Service.UPS -> UPSDeliveryService
+        Service.FPX -> FPXDeliveryService
 
-    Service.UNIUNI -> UniUniDeliveryService
+        Service.UNIUNI -> UniUniDeliveryService
 
-    Service.DPD_UK -> DpdUkDeliveryService
-    Service.EVRI -> EvriDeliveryService
+        Service.DPD_UK -> DpdUkDeliveryService
+        Service.EVRI -> EvriDeliveryService
 
-    Service.AN_POST -> AnPostDeliveryService
-    Service.BELPOST -> BelpostDeliveryService
-    Service.DPD_GER -> DpdGerDeliveryService
-    Service.DPD_PL -> DpdPlDeliveryService
-    Service.GLS_HUNGARY -> GLSHungaryDeliveryService
-    Service.HERMES -> HermesDeliveryService
-    Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
-    Service.NOVA_POSHTA -> NovaPostDeliveryService
-    Service.PACKETA -> PacketaDeliveryService
-    Service.POLISH_POST -> PolishPostDeliveryService
-    Service.POSTE_ITALIANE -> PosteItalianeDeliveryService
-    Service.POST_NL -> PostNLDeliveryService
-    Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
-    Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
-    Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
-    Service.UKRPOSHTA -> UkrposhtaDeliveryService
-    Service.POSTNORD -> PostNordDeliveryService
-    Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
-    Service.INPOST -> InPostDeliveryService
-    Service.INPOST_IT -> InPostItalyDeliveryService
-    Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService
+        Service.AN_POST -> AnPostDeliveryService
+        Service.BELPOST -> BelpostDeliveryService
+        Service.DPD_GER -> DpdGerDeliveryService
+        Service.DPD_PL -> DpdPlDeliveryService
+        Service.GLS_HUNGARY -> GLSHungaryDeliveryService
+        Service.HERMES -> HermesDeliveryService
+        Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
+        Service.NOVA_POSHTA -> NovaPostDeliveryService
+        Service.PACKETA -> PacketaDeliveryService
+        Service.POLISH_POST -> PolishPostDeliveryService
+        Service.POSTE_ITALIANE -> PosteItalianeDeliveryService
+        Service.POST_NL -> PostNLDeliveryService
+        Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
+        Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
+        Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
+        Service.UKRPOSHTA -> UkrposhtaDeliveryService
+        Service.POSTNORD -> PostNordDeliveryService
+        Service.ALLEGRO_ONEBOX -> AllegroOneBoxDeliveryService
+        Service.INPOST -> InPostDeliveryService
+        Service.INPOST_IT -> InPostItalyDeliveryService
+        Service.ORLEN_PACZKA -> OrlenPaczkaDeliveryService
 
-    Service.EKART -> EKartDeliveryService
-    Service.SPX_TH -> SPXThailandDeliveryService
+        Service.EKART -> EKartDeliveryService
+        Service.SPX_TH -> SPXThailandDeliveryService
 
-    Service.EXAMPLE -> ExampleDeliveryService
-    else -> null
-  }
+        Service.EXAMPLE -> ExampleDeliveryService
+        else -> null
+    }
 }
 
 internal val api_client =
@@ -116,7 +118,9 @@ internal val api_client =
             HttpLoggingInterceptor { Log.d("OkHttp", it) }
                 .setLevel(
                     if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-                    else HttpLoggingInterceptor.Level.BASIC))
+                    else HttpLoggingInterceptor.Level.BASIC
+                )
+        )
         .build()
 
 internal val api_moshi: Moshi = Moshi.Builder().build()
@@ -137,69 +141,81 @@ data class ParcelHistoryItem(
 )
 
 enum class Status(val nameResource: Int) {
-  Preadvice(R.string.status_preadvice),
-  LockerboxAcceptedParcel(R.string.status_lockerbox_accepted_parcel),
-  PickedUpByCourier(R.string.status_picked_up_by_courier),
-  InTransit(R.string.status_in_transit),
-  Readdressed(R.string.status_readdressed),
-  InWarehouse(R.string.status_in_warehouse),
-  Customs(R.string.status_customs),
-  CustomsSuccess(R.string.status_customs_cleared),
-  CustomsHeld(R.string.status_customs_held),
-  OutForDelivery(R.string.status_out_for_delivery),
-  DeliveryFailure(R.string.status_delivery_failure),
-  Delivered(R.string.status_delivered),
-  DeliveredToNeighbor(R.string.status_delivered_to_neighbor),
-  DeliveredToASafePlace(R.string.status_delivered_to_a_safe_place),
-  DroppedAtCustomerService(R.string.status_dropped_at_cs),
-  ReturningToSender(R.string.status_returning_to_sender),
-  ReturnedToSender(R.string.status_returned_to_sender),
-  AwaitingPickup(R.string.status_awaiting_pickup),
-  PickupTimeEndingSoon(R.string.status_pickup_time_ending_soon),
-  PickedUp(R.string.status_picked_up),
-  Delayed(R.string.status_delayed),
-  Damaged(R.string.status_damaged),
-  Destroyed(R.string.status_destroyed),
-  Unknown(R.string.status_unknown),
-  NetworkFailure(R.string.status_network_failure),
-  NoData(R.string.status_no_data),
+    Preadvice(R.string.status_preadvice),
+    LockerboxAcceptedParcel(R.string.status_lockerbox_accepted_parcel),
+    PickedUpByCourier(R.string.status_picked_up_by_courier),
+    InTransit(R.string.status_in_transit),
+    Readdressed(R.string.status_readdressed),
+    InWarehouse(R.string.status_in_warehouse),
+    Customs(R.string.status_customs),
+    CustomsSuccess(R.string.status_customs_cleared),
+    CustomsHeld(R.string.status_customs_held),
+    OutForDelivery(R.string.status_out_for_delivery),
+    DeliveryFailure(R.string.status_delivery_failure),
+    Delivered(R.string.status_delivered),
+    DeliveredToNeighbor(R.string.status_delivered_to_neighbor),
+    DeliveredToASafePlace(R.string.status_delivered_to_a_safe_place),
+    DroppedAtCustomerService(R.string.status_dropped_at_cs),
+    ReturningToSender(R.string.status_returning_to_sender),
+    ReturnedToSender(R.string.status_returned_to_sender),
+    AwaitingPickup(R.string.status_awaiting_pickup),
+    PickupTimeEndingSoon(R.string.status_pickup_time_ending_soon),
+    PickedUp(R.string.status_picked_up),
+    Delayed(R.string.status_delayed),
+    Damaged(R.string.status_damaged),
+    Destroyed(R.string.status_destroyed),
+    Unknown(R.string.status_unknown),
+    NetworkFailure(R.string.status_network_failure),
+    NoData(R.string.status_no_data),
 }
 
 suspend fun Context.getParcel(id: String, postCode: String?, service: Service): Parcel {
-  // use DeliveryService abstraction if possible, otherwise default to the old hardcoded list
-  getDeliveryService(service)?.let {
-    return it.getParcel(this, id, postCode)
-  }
+    // use DeliveryService abstraction if possible, otherwise default to the old hardcoded list
+    getDeliveryService(service)?.let {
+        return it.getParcel(this, id, postCode)
+    }
 
-  throw NotImplementedError("Service $service has no DeliveryService object")
+    throw NotImplementedError("Service $service has no DeliveryService object")
 }
 
 fun getDeliveryServiceName(service: Service): Int? {
-  return getDeliveryService(service)?.nameResource
+    return getDeliveryService(service)?.nameResource
 }
 
 interface DeliveryService {
-  val nameResource: Int
-  val acceptsPostCode: Boolean
-  val requiresPostCode: Boolean
-  val requiresApiKey: Boolean
-    get() = false
+    val nameResource: Int
+    val acceptsPostCode: Boolean
+    val requiresPostCode: Boolean
+    val requiresApiKey: Boolean
+        get() = false
 
-  val apiKeyPreference: Preferences.Key<String>?
-    get() = null
+    val apiKeyPreference: Preferences.Key<String>?
+        get() = null
 
-  suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    return TODO("DeliveryService does not implement getParcel")
-  }
+    suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        return TODO("DeliveryService does not implement getParcel")
+    }
 
-  suspend fun getParcel(context: Context, trackingId: String, postalCode: String?): Parcel {
-    return getParcel(trackingId, postalCode)
-  }
+    suspend fun getParcel(context: Context, trackingId: String, postalCode: String?): Parcel {
+        return getParcel(trackingId, postalCode)
+    }
 
-  fun acceptsFormat(trackingId: String): Boolean {
-    return false
-  }
+    fun acceptsFormat(trackingId: String): Boolean {
+        return false
+    }
+
+    // List of patterns that match this provider's public tracking-page URLs.
+    // See TrackingUrlPattern for matching semantics.
+    val trackingUrlPatterns: List<TrackingUrlPattern>
+        get() = emptyList()
 }
+
+// A pattern matching a provider's public tracking-page URLs. urlRegex's first
+// capture group must be the tracking ID; postalCodeRegex, if given, has its own
+// first capture group as the postal code. Both are matched independently with
+// Regex.find() (not matchEntire) against the full URL string, so patterns don't
+// need to anchor the whole string or assume query-param ordering.
+data class TrackingUrlPattern(val urlRegex: Regex, val postalCodeRegex: Regex? = null)
 
 class ParcelNonExistentException : Exception("Parcel does not exist in delivery service API")
 
@@ -207,10 +223,10 @@ class APIKeyMissingException :
     Exception("Delivery service requires an API key but none is present")
 
 internal fun logUnknownStatus(service: String, data: String): Status {
-  Log.d("APICore", "Unknown status reported by $service: $data")
-  return Status.Unknown
+    Log.d("APICore", "Unknown status reported by $service: $data")
+    return Status.Unknown
 }
 
 fun localDateFromMilli(milli: Long): LocalDateTime {
-  return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), TimeZone.getDefault().toZoneId())
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), TimeZone.getDefault().toZoneId())
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
@@ -17,127 +17,130 @@ import retrofit2.http.Header
 import retrofit2.http.Query
 
 object DhlDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_dhl
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
-  override val requiresApiKey: Boolean = true
-  override val apiKeyPreference: Preferences.Key<String>? = DHL_API_KEY
+    override val nameResource: Int = R.string.service_dhl
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
+    override val requiresApiKey: Boolean = true
+    override val apiKeyPreference: Preferences.Key<String>? = DHL_API_KEY
 
-  override fun acceptsFormat(trackingId: String): Boolean {
-    val dhlParcelFormat = """^(?:JJD|JVGL|3S|JV|JD)\d*$""".toRegex()
-    return digits11Format.accepts(trackingId) ||
-        digits12Format.accepts(trackingId) ||
-        digits18Format.accepts(trackingId) ||
-        emsFormat.accepts(trackingId) ||
-        dhlParcelFormat.accepts(trackingId)
-  }
+    // Confirmed: verified against real link
+    // The main dhl.com tracker's own URL format is unconfirmed, so it's not included here.
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            TrackingUrlPattern(
+                """https?://my\.dhlparcel\.nl/go-track-trace\?\S*pid=([A-Za-z0-9]+)"""
+                    .toRegex(RegexOption.IGNORE_CASE)
+            )
+        )
 
-  override suspend fun getParcel(
-      context: Context,
-      trackingId: String,
-      postalCode: String?
-  ): Parcel {
-    val key = context.dataStore.data.first()[apiKeyPreference!!]
-    if (key.isNullOrEmpty()) {
-      throw APIKeyMissingException()
+    override fun acceptsFormat(trackingId: String): Boolean {
+        val dhlParcelFormat = """^(?:JJD|JVGL|3S|JV|JD)\d*$""".toRegex()
+        return digits11Format.accepts(trackingId) ||
+            digits12Format.accepts(trackingId) ||
+            digits18Format.accepts(trackingId) ||
+            emsFormat.accepts(trackingId) ||
+            dhlParcelFormat.accepts(trackingId)
     }
 
-    val resp =
-        try {
-          service.getShipments(key, trackingId)
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
+    override suspend fun getParcel(
+        context: Context,
+        trackingId: String,
+        postalCode: String?,
+    ): Parcel {
+        val key = context.dataStore.data.first()[apiKeyPreference!!]
+        if (key.isNullOrEmpty()) {
+            throw APIKeyMissingException()
         }
 
-    val shipment = resp.shipments.first()
+        val resp =
+            try {
+                service.getShipments(key, trackingId)
+            } catch (_: HttpException) {
+                throw ParcelNonExistentException()
+            }
 
-    val status =
-        when (shipment.status.statusCode) {
-          "unknown" -> Status.Unknown
-          "pre-transit" -> Status.Preadvice
-          "transit" ->
-              when (shipment.status.status) {
-                // DHL uses a "transit" status code for different statues
-                "447" -> Status.Customs // ARRIVED AT CUSTOMS
-                "506" -> Status.Customs // HELD AT CUSTOMS
-                "449" -> Status.Customs // CLEARED CUSTOMS
-                "576" -> Status.InWarehouse // PROCESSED AT LOCAL DISTRIBUTION CENTER
-                "577" -> Status.OutForDelivery // DEPARTED FROM LOCAL DISTRIBUTION CENTER
-                "OUT FOR DELIVERY" -> Status.OutForDelivery
-                else -> Status.InTransit
-              }
+        val shipment = resp.shipments.first()
 
-          "failure" ->
-              when (shipment.status.status) {
-                "103" -> Status.InWarehouse // Shipment is on hold
-                else -> Status.DeliveryFailure
-              }
+        val status =
+            when (shipment.status.statusCode) {
+                "unknown" -> Status.Unknown
+                "pre-transit" -> Status.Preadvice
+                "transit" ->
+                    when (shipment.status.status) {
+                        // DHL uses a "transit" status code for different statues
+                        "447" -> Status.Customs // ARRIVED AT CUSTOMS
+                        "506" -> Status.Customs // HELD AT CUSTOMS
+                        "449" -> Status.Customs // CLEARED CUSTOMS
+                        "576" -> Status.InWarehouse // PROCESSED AT LOCAL DISTRIBUTION CENTER
+                        "577" -> Status.OutForDelivery // DEPARTED FROM LOCAL DISTRIBUTION CENTER
+                        "OUT FOR DELIVERY" -> Status.OutForDelivery
+                        else -> Status.InTransit
+                    }
 
-          "delivered" -> Status.Delivered
-          else -> logUnknownStatus("DHL", shipment.status.statusCode)
-        }
+                "failure" ->
+                    when (shipment.status.status) {
+                        "103" -> Status.InWarehouse // Shipment is on hold
+                        else -> Status.DeliveryFailure
+                    }
 
-    val history =
-        shipment.events.map {
-          ParcelHistoryItem(
-              it.description ?: it.status,
-              LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
-              if (it.location == null) "Unknown location"
-              else if (it.location.address.postalCode != null)
-                  "${it.location.address.postalCode} ${it.location.address.addressLocality}"
-              else it.location.address.addressLocality)
-        }
+                "delivered" -> Status.Delivered
+                else -> logUnknownStatus("DHL", shipment.status.statusCode)
+            }
 
-    return Parcel(shipment.id, history, status)
-  }
+        val history =
+            shipment.events.map {
+                ParcelHistoryItem(
+                    it.description ?: it.status,
+                    LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
+                    if (it.location == null) "Unknown location"
+                    else if (it.location.address.postalCode != null)
+                        "${it.location.address.postalCode} ${it.location.address.addressLocality}"
+                    else it.location.address.addressLocality,
+                )
+            }
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://api-eu.dhl.com/")
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
+        return Parcel(shipment.id, history, status)
+    }
 
-  private val service = retrofit.create(API::class.java)
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://api-eu.dhl.com/")
+            .client(api_client)
+            .addConverterFactory(api_factory)
+            .build()
 
-  private interface API {
-    @GET("track/shipments")
-    suspend fun getShipments(
-        @Header("DHL-API-Key") apiKey: String,
-        @Query("trackingNumber") id: String
-    ): ShipmentsResponse
-  }
+    private val service = retrofit.create(API::class.java)
 
-  @JsonClass(generateAdapter = true)
-  internal data class ShipmentsResponse(
-      val shipments: List<Shipment>,
-  )
+    private interface API {
+        @GET("track/shipments")
+        suspend fun getShipments(
+            @Header("DHL-API-Key") apiKey: String,
+            @Query("trackingNumber") id: String,
+        ): ShipmentsResponse
+    }
 
-  @JsonClass(generateAdapter = true)
-  internal data class Shipment(
-      val id: String,
-      val service: String,
-      val events: List<Event>,
-      val status: Event,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ShipmentsResponse(val shipments: List<Shipment>)
 
-  @JsonClass(generateAdapter = true)
-  internal data class Event(
-      val description: String?,
-      val location: EventLocation?,
-      val status: String,
-      val statusCode: String,
-      val timestamp: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Shipment(
+        val id: String,
+        val service: String,
+        val events: List<Event>,
+        val status: Event,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class EventLocation(
-      val address: Address,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Event(
+        val description: String?,
+        val location: EventLocation?,
+        val status: String,
+        val statusCode: String,
+        val timestamp: String,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class Address(
-      val addressLocality: String,
-      val postalCode: String?,
-  )
+    @JsonClass(generateAdapter = true) internal data class EventLocation(val address: Address)
+
+    @JsonClass(generateAdapter = true)
+    internal data class Address(val addressLocality: String, val postalCode: String?)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
@@ -17,130 +17,128 @@ import retrofit2.http.Header
 import retrofit2.http.Query
 
 object DhlDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_dhl
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
-    override val requiresApiKey: Boolean = true
-    override val apiKeyPreference: Preferences.Key<String>? = DHL_API_KEY
+  override val nameResource: Int = R.string.service_dhl
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
+  override val requiresApiKey: Boolean = true
+  override val apiKeyPreference: Preferences.Key<String>? = DHL_API_KEY
 
-    // Confirmed: verified against real link
-    // The main dhl.com tracker's own URL format is unconfirmed, so it's not included here.
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            TrackingUrlPattern(
-                """https?://my\.dhlparcel\.nl/go-track-trace\?\S*pid=([A-Za-z0-9]+)"""
-                    .toRegex(RegexOption.IGNORE_CASE)
-            )
-        )
+  // Confirmed: verified against real link
+  // The main dhl.com tracker's own URL format is unconfirmed, so it's not included here.
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://my\.dhlparcel\.nl/go-track-trace\?\S*pid=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)))
 
-    override fun acceptsFormat(trackingId: String): Boolean {
-        val dhlParcelFormat = """^(?:JJD|JVGL|3S|JV|JD)\d*$""".toRegex()
-        return digits11Format.accepts(trackingId) ||
-            digits12Format.accepts(trackingId) ||
-            digits18Format.accepts(trackingId) ||
-            emsFormat.accepts(trackingId) ||
-            dhlParcelFormat.accepts(trackingId)
+  override fun acceptsFormat(trackingId: String): Boolean {
+    val dhlParcelFormat = """^(?:JJD|JVGL|3S|JV|JD)\d*$""".toRegex()
+    return digits11Format.accepts(trackingId) ||
+        digits12Format.accepts(trackingId) ||
+        digits18Format.accepts(trackingId) ||
+        emsFormat.accepts(trackingId) ||
+        dhlParcelFormat.accepts(trackingId)
+  }
+
+  override suspend fun getParcel(
+      context: Context,
+      trackingId: String,
+      postalCode: String?,
+  ): Parcel {
+    val key = context.dataStore.data.first()[apiKeyPreference!!]
+    if (key.isNullOrEmpty()) {
+      throw APIKeyMissingException()
     }
 
-    override suspend fun getParcel(
-        context: Context,
-        trackingId: String,
-        postalCode: String?,
-    ): Parcel {
-        val key = context.dataStore.data.first()[apiKeyPreference!!]
-        if (key.isNullOrEmpty()) {
-            throw APIKeyMissingException()
+    val resp =
+        try {
+          service.getShipments(key, trackingId)
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
         }
 
-        val resp =
-            try {
-                service.getShipments(key, trackingId)
-            } catch (_: HttpException) {
-                throw ParcelNonExistentException()
-            }
+    val shipment = resp.shipments.first()
 
-        val shipment = resp.shipments.first()
+    val status =
+        when (shipment.status.statusCode) {
+          "unknown" -> Status.Unknown
+          "pre-transit" -> Status.Preadvice
+          "transit" ->
+              when (shipment.status.status) {
+                // DHL uses a "transit" status code for different statues
+                "447" -> Status.Customs // ARRIVED AT CUSTOMS
+                "506" -> Status.Customs // HELD AT CUSTOMS
+                "449" -> Status.Customs // CLEARED CUSTOMS
+                "576" -> Status.InWarehouse // PROCESSED AT LOCAL DISTRIBUTION CENTER
+                "577" -> Status.OutForDelivery // DEPARTED FROM LOCAL DISTRIBUTION CENTER
+                "OUT FOR DELIVERY" -> Status.OutForDelivery
+                else -> Status.InTransit
+              }
 
-        val status =
-            when (shipment.status.statusCode) {
-                "unknown" -> Status.Unknown
-                "pre-transit" -> Status.Preadvice
-                "transit" ->
-                    when (shipment.status.status) {
-                        // DHL uses a "transit" status code for different statues
-                        "447" -> Status.Customs // ARRIVED AT CUSTOMS
-                        "506" -> Status.Customs // HELD AT CUSTOMS
-                        "449" -> Status.Customs // CLEARED CUSTOMS
-                        "576" -> Status.InWarehouse // PROCESSED AT LOCAL DISTRIBUTION CENTER
-                        "577" -> Status.OutForDelivery // DEPARTED FROM LOCAL DISTRIBUTION CENTER
-                        "OUT FOR DELIVERY" -> Status.OutForDelivery
-                        else -> Status.InTransit
-                    }
+          "failure" ->
+              when (shipment.status.status) {
+                "103" -> Status.InWarehouse // Shipment is on hold
+                else -> Status.DeliveryFailure
+              }
 
-                "failure" ->
-                    when (shipment.status.status) {
-                        "103" -> Status.InWarehouse // Shipment is on hold
-                        else -> Status.DeliveryFailure
-                    }
+          "delivered" -> Status.Delivered
+          else -> logUnknownStatus("DHL", shipment.status.statusCode)
+        }
 
-                "delivered" -> Status.Delivered
-                else -> logUnknownStatus("DHL", shipment.status.statusCode)
-            }
+    val history =
+        shipment.events.map {
+          ParcelHistoryItem(
+              it.description ?: it.status,
+              LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
+              if (it.location == null) "Unknown location"
+              else if (it.location.address.postalCode != null)
+                  "${it.location.address.postalCode} ${it.location.address.addressLocality}"
+              else it.location.address.addressLocality,
+          )
+        }
 
-        val history =
-            shipment.events.map {
-                ParcelHistoryItem(
-                    it.description ?: it.status,
-                    LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
-                    if (it.location == null) "Unknown location"
-                    else if (it.location.address.postalCode != null)
-                        "${it.location.address.postalCode} ${it.location.address.addressLocality}"
-                    else it.location.address.addressLocality,
-                )
-            }
+    return Parcel(shipment.id, history, status)
+  }
 
-        return Parcel(shipment.id, history, status)
-    }
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://api-eu.dhl.com/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://api-eu.dhl.com/")
-            .client(api_client)
-            .addConverterFactory(api_factory)
-            .build()
+  private val service = retrofit.create(API::class.java)
 
-    private val service = retrofit.create(API::class.java)
+  private interface API {
+    @GET("track/shipments")
+    suspend fun getShipments(
+        @Header("DHL-API-Key") apiKey: String,
+        @Query("trackingNumber") id: String,
+    ): ShipmentsResponse
+  }
 
-    private interface API {
-        @GET("track/shipments")
-        suspend fun getShipments(
-            @Header("DHL-API-Key") apiKey: String,
-            @Query("trackingNumber") id: String,
-        ): ShipmentsResponse
-    }
+  @JsonClass(generateAdapter = true)
+  internal data class ShipmentsResponse(val shipments: List<Shipment>)
 
-    @JsonClass(generateAdapter = true)
-    internal data class ShipmentsResponse(val shipments: List<Shipment>)
+  @JsonClass(generateAdapter = true)
+  internal data class Shipment(
+      val id: String,
+      val service: String,
+      val events: List<Event>,
+      val status: Event,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class Shipment(
-        val id: String,
-        val service: String,
-        val events: List<Event>,
-        val status: Event,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Event(
+      val description: String?,
+      val location: EventLocation?,
+      val status: String,
+      val statusCode: String,
+      val timestamp: String,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class Event(
-        val description: String?,
-        val location: EventLocation?,
-        val status: String,
-        val statusCode: String,
-        val timestamp: String,
-    )
+  @JsonClass(generateAdapter = true) internal data class EventLocation(val address: Address)
 
-    @JsonClass(generateAdapter = true) internal data class EventLocation(val address: Address)
-
-    @JsonClass(generateAdapter = true)
-    internal data class Address(val addressLocality: String, val postalCode: String?)
+  @JsonClass(generateAdapter = true)
+  internal data class Address(val addressLocality: String, val postalCode: String?)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
@@ -14,100 +14,100 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 object EvriDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_evri
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
+  override val nameResource: Int = R.string.service_evri
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
 
-    // Tracking URL parsing not yet supported: Evri's confirmed public entry point is
-    // a search form at evri.com/track-a-parcel (barcode typed in manually), not a
-    // confirmed shareable link with the ID in the path/query.
+  // Tracking URL parsing not yet supported: Evri's confirmed public entry point is
+  // a search form at evri.com/track-a-parcel (barcode typed in manually), not a
+  // confirmed shareable link with the ID in the path/query.
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val urnResp =
-            try {
-                val resp = service.getParcelURN(trackingId)
-                if (resp.parcelIdentifiers.isEmpty()) throw ParcelNonExistentException()
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val urnResp =
+        try {
+          val resp = service.getParcelURN(trackingId)
+          if (resp.parcelIdentifiers.isEmpty()) throw ParcelNonExistentException()
 
-                resp
-            } catch (_: HttpException) {
-                throw ParcelNonExistentException()
-            }
+          resp
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
+        }
 
-        val urn = urnResp.parcelIdentifiers.first().urn
-        val parcelResp = service.getParcel(urn)
-        val parcel = parcelResp.results.first()
+    val urn = urnResp.parcelIdentifiers.first().urn
+    val parcelResp = service.getParcel(urn)
+    val parcel = parcelResp.results.first()
 
-        val history =
-            parcel.trackingEvents.map {
-                ParcelHistoryItem(
-                    it.trackingPoint.description,
-                    Instant.parse(it.dateTime).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-                    "",
-                )
-            }
+    val history =
+        parcel.trackingEvents.map {
+          ParcelHistoryItem(
+              it.trackingPoint.description,
+              Instant.parse(it.dateTime).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+              "",
+          )
+        }
 
-        val status =
-            when (parcel.trackingEvents.first().trackingStage.trackingStageCode) {
-                "1" -> Status.Preadvice
-                "2" -> Status.InWarehouse
-                "3" -> Status.InTransit
-                "4_COURIER" -> Status.OutForDelivery
-                "5_COURIER" -> Status.Delivered
-                else ->
-                    logUnknownStatus(
-                        "Evri",
-                        parcel.trackingEvents.first().trackingStage.trackingStageCode,
-                    )
-            }
+    val status =
+        when (parcel.trackingEvents.first().trackingStage.trackingStageCode) {
+          "1" -> Status.Preadvice
+          "2" -> Status.InWarehouse
+          "3" -> Status.InTransit
+          "4_COURIER" -> Status.OutForDelivery
+          "5_COURIER" -> Status.Delivered
+          else ->
+              logUnknownStatus(
+                  "Evri",
+                  parcel.trackingEvents.first().trackingStage.trackingStageCode,
+              )
+        }
 
-        return Parcel(trackingId, history, status)
-    }
+    return Parcel(trackingId, history, status)
+  }
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://api.hermesworld.co.uk/enterprise-tracking-api/v1/")
-            .client(api_client)
-            .addConverterFactory(MoshiConverterFactory.create(api_moshi))
-            .build()
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://api.hermesworld.co.uk/enterprise-tracking-api/v1/")
+          .client(api_client)
+          .addConverterFactory(MoshiConverterFactory.create(api_moshi))
+          .build()
 
-    private val service = retrofit.create(API::class.java)
+  private val service = retrofit.create(API::class.java)
 
-    // TODO: there may be more info with a postcode, but i can't really test that
-    private interface API {
-        @Headers("Apikey: 0DExZiK9in2ihGce7cDPrnpQ4s4nIpWG")
-        @GET("parcels/reference/{id}")
-        suspend fun getParcelURN(@Path("id") trackingId: String): ParcelReferenceResponse
+  // TODO: there may be more info with a postcode, but i can't really test that
+  private interface API {
+    @Headers("Apikey: 0DExZiK9in2ihGce7cDPrnpQ4s4nIpWG")
+    @GET("parcels/reference/{id}")
+    suspend fun getParcelURN(@Path("id") trackingId: String): ParcelReferenceResponse
 
-        @Headers("Apikey: Vi8HZURvXHANfpiFDGta6bJclafLJcAY")
-        @GET("parcels")
-        suspend fun getParcel(@Query("uniqueIds") urn: String): ParcelResponse
-    }
+    @Headers("Apikey: Vi8HZURvXHANfpiFDGta6bJclafLJcAY")
+    @GET("parcels")
+    suspend fun getParcel(@Query("uniqueIds") urn: String): ParcelResponse
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class ParcelReferenceResponse(val parcelIdentifiers: List<ParcelIdentifier>)
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelReferenceResponse(val parcelIdentifiers: List<ParcelIdentifier>)
 
-    @JsonClass(generateAdapter = true) internal data class ParcelIdentifier(val urn: String)
+  @JsonClass(generateAdapter = true) internal data class ParcelIdentifier(val urn: String)
 
-    @JsonClass(generateAdapter = true)
-    internal data class ParcelResponse(
-        val failures: List<FailedQueries>,
-        val results: List<EvriParcel>,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelResponse(
+      val failures: List<FailedQueries>,
+      val results: List<EvriParcel>,
+  )
 
-    @JsonClass(generateAdapter = true) internal data class FailedQueries(val uniqueId: String)
+  @JsonClass(generateAdapter = true) internal data class FailedQueries(val uniqueId: String)
 
-    @JsonClass(generateAdapter = true)
-    internal data class EvriParcel(val trackingEvents: List<Event>)
+  @JsonClass(generateAdapter = true)
+  internal data class EvriParcel(val trackingEvents: List<Event>)
 
-    @JsonClass(generateAdapter = true)
-    internal data class Event(
-        val trackingPoint: TrackingPoint,
-        val trackingStage: TrackingStage,
-        val dateTime: String,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Event(
+      val trackingPoint: TrackingPoint,
+      val trackingStage: TrackingStage,
+      val dateTime: String,
+  )
 
-    @JsonClass(generateAdapter = true) internal data class TrackingPoint(val description: String)
+  @JsonClass(generateAdapter = true) internal data class TrackingPoint(val description: String)
 
-    @JsonClass(generateAdapter = true)
-    internal data class TrackingStage(val trackingStageCode: String)
+  @JsonClass(generateAdapter = true)
+  internal data class TrackingStage(val trackingStageCode: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
@@ -14,108 +14,100 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 object EvriDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_evri
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
+    override val nameResource: Int = R.string.service_evri
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val urnResp =
-        try {
-          val resp = service.getParcelURN(trackingId)
-          if (resp.parcelIdentifiers.isEmpty()) throw ParcelNonExistentException()
+    // Tracking URL parsing not yet supported: Evri's confirmed public entry point is
+    // a search form at evri.com/track-a-parcel (barcode typed in manually), not a
+    // confirmed shareable link with the ID in the path/query.
 
-          resp
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
-        }
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val urnResp =
+            try {
+                val resp = service.getParcelURN(trackingId)
+                if (resp.parcelIdentifiers.isEmpty()) throw ParcelNonExistentException()
 
-    val urn = urnResp.parcelIdentifiers.first().urn
-    val parcelResp = service.getParcel(urn)
-    val parcel = parcelResp.results.first()
+                resp
+            } catch (_: HttpException) {
+                throw ParcelNonExistentException()
+            }
 
-    val history =
-        parcel.trackingEvents.map {
-          ParcelHistoryItem(
-              it.trackingPoint.description,
-              Instant.parse(it.dateTime).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-              "")
-        }
+        val urn = urnResp.parcelIdentifiers.first().urn
+        val parcelResp = service.getParcel(urn)
+        val parcel = parcelResp.results.first()
 
-    val status =
-        when (parcel.trackingEvents.first().trackingStage.trackingStageCode) {
-          "1" -> Status.Preadvice
-          "2" -> Status.InWarehouse
-          "3" -> Status.InTransit
-          "4_COURIER" -> Status.OutForDelivery
-          "5_COURIER" -> Status.Delivered
-          else ->
-              logUnknownStatus(
-                  "Evri", parcel.trackingEvents.first().trackingStage.trackingStageCode)
-        }
+        val history =
+            parcel.trackingEvents.map {
+                ParcelHistoryItem(
+                    it.trackingPoint.description,
+                    Instant.parse(it.dateTime).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+                    "",
+                )
+            }
 
-    return Parcel(trackingId, history, status)
-  }
+        val status =
+            when (parcel.trackingEvents.first().trackingStage.trackingStageCode) {
+                "1" -> Status.Preadvice
+                "2" -> Status.InWarehouse
+                "3" -> Status.InTransit
+                "4_COURIER" -> Status.OutForDelivery
+                "5_COURIER" -> Status.Delivered
+                else ->
+                    logUnknownStatus(
+                        "Evri",
+                        parcel.trackingEvents.first().trackingStage.trackingStageCode,
+                    )
+            }
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://api.hermesworld.co.uk/enterprise-tracking-api/v1/")
-          .client(api_client)
-          .addConverterFactory(MoshiConverterFactory.create(api_moshi))
-          .build()
+        return Parcel(trackingId, history, status)
+    }
 
-  private val service = retrofit.create(API::class.java)
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://api.hermesworld.co.uk/enterprise-tracking-api/v1/")
+            .client(api_client)
+            .addConverterFactory(MoshiConverterFactory.create(api_moshi))
+            .build()
 
-  // TODO: there may be more info with a postcode, but i can't really test that
-  private interface API {
-    @Headers("Apikey: 0DExZiK9in2ihGce7cDPrnpQ4s4nIpWG")
-    @GET("parcels/reference/{id}")
-    suspend fun getParcelURN(@Path("id") trackingId: String): ParcelReferenceResponse
+    private val service = retrofit.create(API::class.java)
 
-    @Headers("Apikey: Vi8HZURvXHANfpiFDGta6bJclafLJcAY")
-    @GET("parcels")
-    suspend fun getParcel(@Query("uniqueIds") urn: String): ParcelResponse
-  }
+    // TODO: there may be more info with a postcode, but i can't really test that
+    private interface API {
+        @Headers("Apikey: 0DExZiK9in2ihGce7cDPrnpQ4s4nIpWG")
+        @GET("parcels/reference/{id}")
+        suspend fun getParcelURN(@Path("id") trackingId: String): ParcelReferenceResponse
 
-  @JsonClass(generateAdapter = true)
-  internal data class ParcelReferenceResponse(
-      val parcelIdentifiers: List<ParcelIdentifier>,
-  )
+        @Headers("Apikey: Vi8HZURvXHANfpiFDGta6bJclafLJcAY")
+        @GET("parcels")
+        suspend fun getParcel(@Query("uniqueIds") urn: String): ParcelResponse
+    }
 
-  @JsonClass(generateAdapter = true)
-  internal data class ParcelIdentifier(
-      val urn: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ParcelReferenceResponse(val parcelIdentifiers: List<ParcelIdentifier>)
 
-  @JsonClass(generateAdapter = true)
-  internal data class ParcelResponse(
-      val failures: List<FailedQueries>,
-      val results: List<EvriParcel>,
-  )
+    @JsonClass(generateAdapter = true) internal data class ParcelIdentifier(val urn: String)
 
-  @JsonClass(generateAdapter = true)
-  internal data class FailedQueries(
-      val uniqueId: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ParcelResponse(
+        val failures: List<FailedQueries>,
+        val results: List<EvriParcel>,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class EvriParcel(
-      val trackingEvents: List<Event>,
-  )
+    @JsonClass(generateAdapter = true) internal data class FailedQueries(val uniqueId: String)
 
-  @JsonClass(generateAdapter = true)
-  internal data class Event(
-      val trackingPoint: TrackingPoint,
-      val trackingStage: TrackingStage,
-      val dateTime: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class EvriParcel(val trackingEvents: List<Event>)
 
-  @JsonClass(generateAdapter = true)
-  internal data class TrackingPoint(
-      val description: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Event(
+        val trackingPoint: TrackingPoint,
+        val trackingStage: TrackingStage,
+        val dateTime: String,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class TrackingStage(
-      val trackingStageCode: String,
-  )
+    @JsonClass(generateAdapter = true) internal data class TrackingPoint(val description: String)
+
+    @JsonClass(generateAdapter = true)
+    internal data class TrackingStage(val trackingStageCode: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
@@ -16,134 +16,132 @@ import retrofit2.http.Query
 // Reverse-engineered from their private API. Pretty basic at least
 
 object GLSGlobalDeliveryService : GLSDeliveryService(R.string.service_gls, "GROUP") {
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            // Confirmed: verified against real link
-            TrackingUrlPattern(
-                """https?://(?:www\.)?gls-group\.(?:eu|com)/\S*[?&]match=([A-Za-z0-9]+)"""
-                    .toRegex(RegexOption.IGNORE_CASE)
-            ),
-            // Confirmed: verified againt real link
-            // Other country TLDs (de, fr, be, at, ...) may follow the same pattern but that's
-            // unverified, so not included here.
-            TrackingUrlPattern(
-                urlRegex =
-                    """https?://(?:www\.)?gls-info\.nl/tracking/ttlink\?\S*parcelNo=([A-Za-z0-9]+)"""
-                        .toRegex(RegexOption.IGNORE_CASE),
-                postalCodeRegex = """[?&]zipCode=([A-Za-z0-9]+)""".toRegex(RegexOption.IGNORE_CASE),
-            ),
-        )
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          // Confirmed: verified against real link
+          TrackingUrlPattern(
+              """https?://(?:www\.)?gls-group\.(?:eu|com)/\S*[?&]match=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)),
+          // Confirmed: verified againt real link
+          // Other country TLDs (de, fr, be, at, ...) may follow the same pattern but that's
+          // unverified, so not included here.
+          TrackingUrlPattern(
+              urlRegex =
+                  """https?://(?:www\.)?gls-info\.nl/tracking/ttlink\?\S*parcelNo=([A-Za-z0-9]+)"""
+                      .toRegex(RegexOption.IGNORE_CASE),
+              postalCodeRegex = """[?&]zipCode=([A-Za-z0-9]+)""".toRegex(RegexOption.IGNORE_CASE),
+          ),
+      )
 }
 
 object GLSHungaryDeliveryService : GLSDeliveryService(R.string.service_gls_hungary, "HU")
 
 open class GLSDeliveryService(override val nameResource: Int, region: String) : DeliveryService {
-    override val acceptsPostCode: Boolean = true
-    override val requiresPostCode: Boolean = true
+  override val acceptsPostCode: Boolean = true
+  override val requiresPostCode: Boolean = true
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val locale = LocaleList.getDefault().get(0).language
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val locale = LocaleList.getDefault().get(0).language
 
-        val resp =
-            try {
-                service.getExtendedParcel(id = trackingId, postalCode = postCode!!, locale = locale)
-            } catch (_: HttpException) {
-                throw ParcelNonExistentException()
-            }
-
-        val history =
-            resp.history.map { item ->
-                ParcelHistoryItem(
-                    Html.fromHtml(item.evtDscr, Html.FROM_HTML_MODE_LEGACY).toString(),
-                    LocalDateTime.parse(
-                        "${item.date}T${item.time}",
-                        DateTimeFormatter.ISO_DATE_TIME,
-                    ),
-                    when {
-                        item.address.countryName == null && item.address.city.isNotEmpty() ->
-                            item.address.city
-                        item.address.countryName != null && item.address.city.isNotEmpty() ->
-                            "${item.address.city}, ${item.address.countryName}"
-                        item.address.countryName != null && item.address.city.isEmpty() ->
-                            item.address.countryName
-                        else -> ""
-                    },
-                )
-            }
-
-        val status =
-            when (resp.progressBar.statusInfo) {
-                "PREADVICE" -> Status.Preadvice
-                "INPICKUP",
-                "INTRANSIT" -> Status.InTransit
-                "INWAREHOUSE" -> Status.InWarehouse
-                "INDELIVERY" -> Status.OutForDelivery
-                "DELIVEREDPS" -> Status.AwaitingPickup
-                "DELIVERED" -> Status.Delivered
-                else -> logUnknownStatus("GLS", resp.progressBar.statusInfo)
-            }
-
-        val properties = mutableMapOf<Int, String>()
-
-        resp.infos?.forEach {
-            if (it.type == "WEIGHT") {
-                properties[R.string.property_weight] = it.value
-            }
+    val resp =
+        try {
+          service.getExtendedParcel(id = trackingId, postalCode = postCode!!, locale = locale)
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
         }
 
-        if (resp.arrivalTime != null) {
-            val type =
-                if (status == Status.Delivered) R.string.property_delivery_time
-                else R.string.property_eta
-            properties[type] = resp.arrivalTime.value
+    val history =
+        resp.history.map { item ->
+          ParcelHistoryItem(
+              Html.fromHtml(item.evtDscr, Html.FROM_HTML_MODE_LEGACY).toString(),
+              LocalDateTime.parse(
+                  "${item.date}T${item.time}",
+                  DateTimeFormatter.ISO_DATE_TIME,
+              ),
+              when {
+                item.address.countryName == null && item.address.city.isNotEmpty() ->
+                    item.address.city
+                item.address.countryName != null && item.address.city.isNotEmpty() ->
+                    "${item.address.city}, ${item.address.countryName}"
+                item.address.countryName != null && item.address.city.isEmpty() ->
+                    item.address.countryName
+                else -> ""
+              },
+          )
         }
 
-        val parcel = Parcel(trackingId, history, status, properties)
-        return parcel
+    val status =
+        when (resp.progressBar.statusInfo) {
+          "PREADVICE" -> Status.Preadvice
+          "INPICKUP",
+          "INTRANSIT" -> Status.InTransit
+          "INWAREHOUSE" -> Status.InWarehouse
+          "INDELIVERY" -> Status.OutForDelivery
+          "DELIVEREDPS" -> Status.AwaitingPickup
+          "DELIVERED" -> Status.Delivered
+          else -> logUnknownStatus("GLS", resp.progressBar.statusInfo)
+        }
+
+    val properties = mutableMapOf<Int, String>()
+
+    resp.infos?.forEach {
+      if (it.type == "WEIGHT") {
+        properties[R.string.property_weight] = it.value
+      }
     }
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://gls-group.com/app/service/open/rest/${region}/")
-            .client(api_client)
-            .addConverterFactory(api_factory)
-            .build()
-    private val service = retrofit.create(API::class.java)
-
-    private interface API {
-        @GET("{locale}/rstt028/{id}")
-        suspend fun getExtendedParcel(
-            @Path("locale") locale: String,
-            @Path("id") id: String,
-            @Query("postalCode") postalCode: String,
-        ): ExtendedParcelInfo
+    if (resp.arrivalTime != null) {
+      val type =
+          if (status == Status.Delivered) R.string.property_delivery_time else R.string.property_eta
+      properties[type] = resp.arrivalTime.value
     }
 
-    @JsonClass(generateAdapter = true)
-    internal data class ExtendedParcelInfo(
-        val history: List<GLSHistoryItem>,
-        val progressBar: Progress,
-        val infos: List<GLSTypedProperty>?,
-        val references: List<GLSTypedProperty>,
-        val arrivalTime: GLSProperty?,
-    )
+    val parcel = Parcel(trackingId, history, status, properties)
+    return parcel
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class GLSTypedProperty(val type: String, val name: String, val value: String)
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://gls-group.com/app/service/open/rest/${region}/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
+  private val service = retrofit.create(API::class.java)
 
-    @JsonClass(generateAdapter = true)
-    internal data class GLSProperty(val name: String, val value: String)
+  private interface API {
+    @GET("{locale}/rstt028/{id}")
+    suspend fun getExtendedParcel(
+        @Path("locale") locale: String,
+        @Path("id") id: String,
+        @Query("postalCode") postalCode: String,
+    ): ExtendedParcelInfo
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class GLSHistoryItem(
-        val time: String,
-        val date: String,
-        val evtDscr: String,
-        val address: HistoryAddress,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class ExtendedParcelInfo(
+      val history: List<GLSHistoryItem>,
+      val progressBar: Progress,
+      val infos: List<GLSTypedProperty>?,
+      val references: List<GLSTypedProperty>,
+      val arrivalTime: GLSProperty?,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class HistoryAddress(val city: String, val countryName: String?)
+  @JsonClass(generateAdapter = true)
+  internal data class GLSTypedProperty(val type: String, val name: String, val value: String)
 
-    @JsonClass(generateAdapter = true) internal data class Progress(val statusInfo: String)
+  @JsonClass(generateAdapter = true)
+  internal data class GLSProperty(val name: String, val value: String)
+
+  @JsonClass(generateAdapter = true)
+  internal data class GLSHistoryItem(
+      val time: String,
+      val date: String,
+      val evtDscr: String,
+      val address: HistoryAddress,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class HistoryAddress(val city: String, val countryName: String?)
+
+  @JsonClass(generateAdapter = true) internal data class Progress(val statusInfo: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
@@ -22,15 +22,6 @@ object GLSGlobalDeliveryService : GLSDeliveryService(R.string.service_gls, "GROU
           TrackingUrlPattern(
               """https?://(?:www\.)?gls-group\.(?:eu|com)/\S*[?&]match=([A-Za-z0-9]+)"""
                   .toRegex(RegexOption.IGNORE_CASE)),
-          // Confirmed: verified againt real link
-          // Other country TLDs (de, fr, be, at, ...) may follow the same pattern but that's
-          // unverified, so not included here.
-          TrackingUrlPattern(
-              urlRegex =
-                  """https?://(?:www\.)?gls-info\.nl/tracking/ttlink\?\S*parcelNo=([A-Za-z0-9]+)"""
-                      .toRegex(RegexOption.IGNORE_CASE),
-              postalCodeRegex = """[?&]zipCode=([A-Za-z0-9]+)""".toRegex(RegexOption.IGNORE_CASE),
-          ),
       )
 }
 

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
@@ -15,125 +15,135 @@ import retrofit2.http.Query
 
 // Reverse-engineered from their private API. Pretty basic at least
 
-object GLSGlobalDeliveryService : GLSDeliveryService(R.string.service_gls, "GROUP")
+object GLSGlobalDeliveryService : GLSDeliveryService(R.string.service_gls, "GROUP") {
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            // Confirmed: verified against real link
+            TrackingUrlPattern(
+                """https?://(?:www\.)?gls-group\.(?:eu|com)/\S*[?&]match=([A-Za-z0-9]+)"""
+                    .toRegex(RegexOption.IGNORE_CASE)
+            ),
+            // Confirmed: verified againt real link
+            // Other country TLDs (de, fr, be, at, ...) may follow the same pattern but that's
+            // unverified, so not included here.
+            TrackingUrlPattern(
+                urlRegex =
+                    """https?://(?:www\.)?gls-info\.nl/tracking/ttlink\?\S*parcelNo=([A-Za-z0-9]+)"""
+                        .toRegex(RegexOption.IGNORE_CASE),
+                postalCodeRegex = """[?&]zipCode=([A-Za-z0-9]+)""".toRegex(RegexOption.IGNORE_CASE),
+            ),
+        )
+}
 
 object GLSHungaryDeliveryService : GLSDeliveryService(R.string.service_gls_hungary, "HU")
 
 open class GLSDeliveryService(override val nameResource: Int, region: String) : DeliveryService {
-  override val acceptsPostCode: Boolean = true
-  override val requiresPostCode: Boolean = true
+    override val acceptsPostCode: Boolean = true
+    override val requiresPostCode: Boolean = true
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val locale = LocaleList.getDefault().get(0).language
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val locale = LocaleList.getDefault().get(0).language
 
-    val resp =
-        try {
-          service.getExtendedParcel(id = trackingId, postalCode = postCode!!, locale = locale)
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
+        val resp =
+            try {
+                service.getExtendedParcel(id = trackingId, postalCode = postCode!!, locale = locale)
+            } catch (_: HttpException) {
+                throw ParcelNonExistentException()
+            }
+
+        val history =
+            resp.history.map { item ->
+                ParcelHistoryItem(
+                    Html.fromHtml(item.evtDscr, Html.FROM_HTML_MODE_LEGACY).toString(),
+                    LocalDateTime.parse(
+                        "${item.date}T${item.time}",
+                        DateTimeFormatter.ISO_DATE_TIME,
+                    ),
+                    when {
+                        item.address.countryName == null && item.address.city.isNotEmpty() ->
+                            item.address.city
+                        item.address.countryName != null && item.address.city.isNotEmpty() ->
+                            "${item.address.city}, ${item.address.countryName}"
+                        item.address.countryName != null && item.address.city.isEmpty() ->
+                            item.address.countryName
+                        else -> ""
+                    },
+                )
+            }
+
+        val status =
+            when (resp.progressBar.statusInfo) {
+                "PREADVICE" -> Status.Preadvice
+                "INPICKUP",
+                "INTRANSIT" -> Status.InTransit
+                "INWAREHOUSE" -> Status.InWarehouse
+                "INDELIVERY" -> Status.OutForDelivery
+                "DELIVEREDPS" -> Status.AwaitingPickup
+                "DELIVERED" -> Status.Delivered
+                else -> logUnknownStatus("GLS", resp.progressBar.statusInfo)
+            }
+
+        val properties = mutableMapOf<Int, String>()
+
+        resp.infos?.forEach {
+            if (it.type == "WEIGHT") {
+                properties[R.string.property_weight] = it.value
+            }
         }
 
-    val history =
-        resp.history.map { item ->
-          ParcelHistoryItem(
-              Html.fromHtml(item.evtDscr, Html.FROM_HTML_MODE_LEGACY).toString(),
-              LocalDateTime.parse("${item.date}T${item.time}", DateTimeFormatter.ISO_DATE_TIME),
-              when {
-                item.address.countryName == null && item.address.city.isNotEmpty() ->
-                    item.address.city
-                item.address.countryName != null && item.address.city.isNotEmpty() ->
-                    "${item.address.city}, ${item.address.countryName}"
-                item.address.countryName != null && item.address.city.isEmpty() ->
-                    item.address.countryName
-                else -> ""
-              })
+        if (resp.arrivalTime != null) {
+            val type =
+                if (status == Status.Delivered) R.string.property_delivery_time
+                else R.string.property_eta
+            properties[type] = resp.arrivalTime.value
         }
 
-    val status =
-        when (resp.progressBar.statusInfo) {
-          "PREADVICE" -> Status.Preadvice
-          "INPICKUP",
-          "INTRANSIT" -> Status.InTransit
-          "INWAREHOUSE" -> Status.InWarehouse
-          "INDELIVERY" -> Status.OutForDelivery
-          "DELIVEREDPS" -> Status.AwaitingPickup
-          "DELIVERED" -> Status.Delivered
-          else -> logUnknownStatus("GLS", resp.progressBar.statusInfo)
-        }
-
-    val properties = mutableMapOf<Int, String>()
-
-    resp.infos?.forEach {
-      if (it.type == "WEIGHT") {
-        properties[R.string.property_weight] = it.value
-      }
+        val parcel = Parcel(trackingId, history, status, properties)
+        return parcel
     }
 
-    if (resp.arrivalTime != null) {
-      val type =
-          if (status == Status.Delivered) R.string.property_delivery_time else R.string.property_eta
-      properties[type] = resp.arrivalTime.value
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://gls-group.com/app/service/open/rest/${region}/")
+            .client(api_client)
+            .addConverterFactory(api_factory)
+            .build()
+    private val service = retrofit.create(API::class.java)
+
+    private interface API {
+        @GET("{locale}/rstt028/{id}")
+        suspend fun getExtendedParcel(
+            @Path("locale") locale: String,
+            @Path("id") id: String,
+            @Query("postalCode") postalCode: String,
+        ): ExtendedParcelInfo
     }
 
-    val parcel = Parcel(trackingId, history, status, properties)
-    return parcel
-  }
+    @JsonClass(generateAdapter = true)
+    internal data class ExtendedParcelInfo(
+        val history: List<GLSHistoryItem>,
+        val progressBar: Progress,
+        val infos: List<GLSTypedProperty>?,
+        val references: List<GLSTypedProperty>,
+        val arrivalTime: GLSProperty?,
+    )
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://gls-group.com/app/service/open/rest/${region}/")
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
-  private val service = retrofit.create(API::class.java)
+    @JsonClass(generateAdapter = true)
+    internal data class GLSTypedProperty(val type: String, val name: String, val value: String)
 
-  private interface API {
-    @GET("{locale}/rstt028/{id}")
-    suspend fun getExtendedParcel(
-        @Path("locale") locale: String,
-        @Path("id") id: String,
-        @Query("postalCode") postalCode: String,
-    ): ExtendedParcelInfo
-  }
+    @JsonClass(generateAdapter = true)
+    internal data class GLSProperty(val name: String, val value: String)
 
-  @JsonClass(generateAdapter = true)
-  internal data class ExtendedParcelInfo(
-      val history: List<GLSHistoryItem>,
-      val progressBar: Progress,
-      val infos: List<GLSTypedProperty>?,
-      val references: List<GLSTypedProperty>,
-      val arrivalTime: GLSProperty?,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class GLSHistoryItem(
+        val time: String,
+        val date: String,
+        val evtDscr: String,
+        val address: HistoryAddress,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class GLSTypedProperty(
-      val type: String,
-      val name: String,
-      val value: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class HistoryAddress(val city: String, val countryName: String?)
 
-  @JsonClass(generateAdapter = true)
-  internal data class GLSProperty(
-      val name: String,
-      val value: String,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class GLSHistoryItem(
-      val time: String,
-      val date: String,
-      val evtDscr: String,
-      val address: HistoryAddress,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class HistoryAddress(
-      val city: String,
-      val countryName: String?,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class Progress(
-      val statusInfo: String,
-  )
+    @JsonClass(generateAdapter = true) internal data class Progress(val statusInfo: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
@@ -19,6 +19,15 @@ object GLSNetherlandsDeliveryService : DeliveryService {
   override val acceptsPostCode: Boolean = true
   override val requiresPostCode: Boolean = true
 
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              urlRegex =
+                  """https?://(?:www\.)?gls-info\.nl/tracking/ttlink\?\S*parcelNo=([A-Za-z0-9]+)"""
+                      .toRegex(RegexOption.IGNORE_CASE),
+              postalCodeRegex = """[?&]zipCode=([A-Za-z0-9]+)""".toRegex(RegexOption.IGNORE_CASE),
+          ))
+
   override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
     // the site only ships nl and en translations; anything else falls back to English
     val culture = if (LocaleList.getDefault().get(0).language == "nl") "nl-NL" else "en-GB"

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
@@ -15,138 +15,147 @@ import retrofit2.http.Headers
 import retrofit2.http.Path
 
 object InPostDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_inpost
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
+    override val nameResource: Int = R.string.service_inpost
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
 
-  private const val BASE_URL = "https://api-shipx-pl.easypack24.net/v1/"
+    // Confirmed: documented public format, inpost.pl/sledzenie-przesylki?number=.
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            TrackingUrlPattern(
+                """https?://(?:www\.)?inpost\.pl/\S*[?&]number=(\d{24})"""
+                    .toRegex(RegexOption.IGNORE_CASE)
+            )
+        )
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl(BASE_URL)
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
+    private const val BASE_URL = "https://api-shipx-pl.easypack24.net/v1/"
 
-  private val service = retrofit.create(API::class.java)
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(api_client)
+            .addConverterFactory(api_factory)
+            .build()
 
-  override fun acceptsFormat(trackingId: String): Boolean {
-    val inpostRegex = """^\d{24}$""".toRegex()
-    return inpostRegex.matchEntire(trackingId) != null
-  }
+    private val service = retrofit.create(API::class.java)
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val response =
-        try {
-          service.getParcel(trackingId)
-        } catch (e: HttpException) {
-          if (e.code() == 400 || e.code() == 404) throw ParcelNonExistentException()
-          throw e
+    override fun acceptsFormat(trackingId: String): Boolean {
+        val inpostRegex = """^\d{24}$""".toRegex()
+        return inpostRegex.matchEntire(trackingId) != null
+    }
+
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val response =
+            try {
+                service.getParcel(trackingId)
+            } catch (e: HttpException) {
+                if (e.code() == 400 || e.code() == 404) throw ParcelNonExistentException()
+                throw e
+            }
+
+        return Parcel(
+            response.trackingNumber,
+            eventsToHistory(response.trackingDetails),
+            statusToEnum(response.status),
+        )
+    }
+
+    internal fun statusToEnum(status: String): Status =
+        when (status) {
+            "created",
+            "offers_prepared",
+            "offer_selected",
+            "confirmed" -> Status.Preadvice
+
+            "collected_from_sender",
+            "taken_by_courier",
+            "taken_by_courier_from_pok",
+            "taken_by_courier_from_customer_service_point" -> Status.PickedUpByCourier
+
+            "adopted_at_source_branch",
+            "adopted_at_sorting_center",
+            "adopted_at_target_branch",
+            "stack_in_customer_service_point",
+            "stack_in_box_machine" -> Status.InWarehouse
+
+            "dispatched_by_sender",
+            "dispatched_by_sender_to_pok",
+            "sent_from_source_branch",
+            "sent_from_sorting_center",
+            "unstack_from_customer_service_point",
+            "unstack_from_box_machine" -> Status.InTransit
+
+            "out_for_delivery",
+            "out_for_delivery_to_address" -> Status.OutForDelivery
+
+            "ready_to_pickup",
+            "ready_to_pickup_from_pok",
+            "ready_to_pickup_from_pok_registered",
+            "ready_to_pickup_from_branch",
+            "avizo",
+            "courier_avizo_in_customer_service_point" -> Status.AwaitingPickup
+
+            "pickup_reminder_sent",
+            "pickup_reminder_sent_address" -> Status.PickupTimeEndingSoon
+
+            "readdressed",
+            "redirect_to_box" -> Status.Readdressed
+
+            "return_pickup_confirmation_to_sender" -> Status.Delivered
+            "returned_to_sender" -> Status.ReturnedToSender
+            "delay_in_delivery" -> Status.Delayed
+            "delivered" -> Status.Delivered
+            "other" -> Status.Unknown
+
+            "oversized",
+            "pickup_time_expired",
+            "claimed",
+            "rejected_by_receiver",
+            "undelivered",
+            "undelivered_wrong_address",
+            "undelivered_incomplete_address",
+            "undelivered_unknown_receiver",
+            "undelivered_cod_cash_receiver",
+            "undelivered_no_mailbox",
+            "undelivered_not_live_address",
+            "undelivered_lack_of_access_letterbox",
+            "canceled",
+            "canceled_redirect_to_box",
+            "stack_parcel_pickup_time_expired",
+            "stack_parcel_in_box_machine_pickup_time_expired",
+            "missing" -> Status.DeliveryFailure
+
+            else -> logUnknownStatus("InPost", status)
         }
 
-    return Parcel(
-        response.trackingNumber,
-        eventsToHistory(response.trackingDetails),
-        statusToEnum(response.status),
+    private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
+        details.map { item ->
+            ParcelHistoryItem(
+                item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
+                LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+                item.location ?: item.agency ?: "",
+            )
+        }
+
+    private interface API {
+        @GET("tracking/{trackingId}")
+        @Headers("Accept: application/json")
+        suspend fun getParcel(@Path("trackingId") trackingId: String): TrackingResponse
+    }
+
+    @JsonClass(generateAdapter = true)
+    internal data class TrackingResponse(
+        @Json(name = "tracking_number") val trackingNumber: String,
+        val status: String,
+        @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
     )
-  }
 
-  internal fun statusToEnum(status: String): Status =
-      when (status) {
-        "created",
-        "offers_prepared",
-        "offer_selected",
-        "confirmed", -> Status.Preadvice
-
-        "collected_from_sender",
-        "taken_by_courier",
-        "taken_by_courier_from_pok",
-        "taken_by_courier_from_customer_service_point", -> Status.PickedUpByCourier
-
-        "adopted_at_source_branch",
-        "adopted_at_sorting_center",
-        "adopted_at_target_branch",
-        "stack_in_customer_service_point",
-        "stack_in_box_machine", -> Status.InWarehouse
-
-        "dispatched_by_sender",
-        "dispatched_by_sender_to_pok",
-        "sent_from_source_branch",
-        "sent_from_sorting_center",
-        "unstack_from_customer_service_point",
-        "unstack_from_box_machine", -> Status.InTransit
-
-        "out_for_delivery",
-        "out_for_delivery_to_address", -> Status.OutForDelivery
-
-        "ready_to_pickup",
-        "ready_to_pickup_from_pok",
-        "ready_to_pickup_from_pok_registered",
-        "ready_to_pickup_from_branch",
-        "avizo",
-        "courier_avizo_in_customer_service_point", -> Status.AwaitingPickup
-
-        "pickup_reminder_sent",
-        "pickup_reminder_sent_address", -> Status.PickupTimeEndingSoon
-
-        "readdressed",
-        "redirect_to_box" -> Status.Readdressed
-
-        "return_pickup_confirmation_to_sender" -> Status.Delivered
-        "returned_to_sender" -> Status.ReturnedToSender
-        "delay_in_delivery" -> Status.Delayed
-        "delivered" -> Status.Delivered
-        "other" -> Status.Unknown
-
-        "oversized",
-        "pickup_time_expired",
-        "claimed",
-        "rejected_by_receiver",
-        "undelivered",
-        "undelivered_wrong_address",
-        "undelivered_incomplete_address",
-        "undelivered_unknown_receiver",
-        "undelivered_cod_cash_receiver",
-        "undelivered_no_mailbox",
-        "undelivered_not_live_address",
-        "undelivered_lack_of_access_letterbox",
-        "canceled",
-        "canceled_redirect_to_box",
-        "stack_parcel_pickup_time_expired",
-        "stack_parcel_in_box_machine_pickup_time_expired",
-        "missing", -> Status.DeliveryFailure
-
-        else -> logUnknownStatus("InPost", status)
-      }
-
-  private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
-      details.map { item ->
-        ParcelHistoryItem(
-            item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
-            LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
-            item.location ?: item.agency ?: "",
-        )
-      }
-
-  private interface API {
-    @GET("tracking/{trackingId}")
-    @Headers("Accept: application/json")
-    suspend fun getParcel(@Path("trackingId") trackingId: String): TrackingResponse
-  }
-
-  @JsonClass(generateAdapter = true)
-  internal data class TrackingResponse(
-      @Json(name = "tracking_number") val trackingNumber: String,
-      val status: String,
-      @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class TrackingDetail(
-      @Json(name = "origin_status") val originStatus: String?,
-      val status: String,
-      val agency: String?,
-      val location: String?,
-      val datetime: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class TrackingDetail(
+        @Json(name = "origin_status") val originStatus: String?,
+        val status: String,
+        val agency: String?,
+        val location: String?,
+        val datetime: String,
+    )
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
@@ -15,147 +15,145 @@ import retrofit2.http.Headers
 import retrofit2.http.Path
 
 object InPostDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_inpost
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
+  override val nameResource: Int = R.string.service_inpost
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
 
-    // Confirmed: documented public format, inpost.pl/sledzenie-przesylki?number=.
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            TrackingUrlPattern(
-                """https?://(?:www\.)?inpost\.pl/\S*[?&]number=(\d{24})"""
-                    .toRegex(RegexOption.IGNORE_CASE)
-            )
-        )
+  // Confirmed: documented public format, inpost.pl/sledzenie-przesylki?number=.
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://(?:www\.)?inpost\.pl/\S*[?&]number=(\d{24})"""
+                  .toRegex(RegexOption.IGNORE_CASE)))
 
-    private const val BASE_URL = "https://api-shipx-pl.easypack24.net/v1/"
+  private const val BASE_URL = "https://api-shipx-pl.easypack24.net/v1/"
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(api_client)
-            .addConverterFactory(api_factory)
-            .build()
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl(BASE_URL)
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
 
-    private val service = retrofit.create(API::class.java)
+  private val service = retrofit.create(API::class.java)
 
-    override fun acceptsFormat(trackingId: String): Boolean {
-        val inpostRegex = """^\d{24}$""".toRegex()
-        return inpostRegex.matchEntire(trackingId) != null
-    }
+  override fun acceptsFormat(trackingId: String): Boolean {
+    val inpostRegex = """^\d{24}$""".toRegex()
+    return inpostRegex.matchEntire(trackingId) != null
+  }
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val response =
-            try {
-                service.getParcel(trackingId)
-            } catch (e: HttpException) {
-                if (e.code() == 400 || e.code() == 404) throw ParcelNonExistentException()
-                throw e
-            }
-
-        return Parcel(
-            response.trackingNumber,
-            eventsToHistory(response.trackingDetails),
-            statusToEnum(response.status),
-        )
-    }
-
-    internal fun statusToEnum(status: String): Status =
-        when (status) {
-            "created",
-            "offers_prepared",
-            "offer_selected",
-            "confirmed" -> Status.Preadvice
-
-            "collected_from_sender",
-            "taken_by_courier",
-            "taken_by_courier_from_pok",
-            "taken_by_courier_from_customer_service_point" -> Status.PickedUpByCourier
-
-            "adopted_at_source_branch",
-            "adopted_at_sorting_center",
-            "adopted_at_target_branch",
-            "stack_in_customer_service_point",
-            "stack_in_box_machine" -> Status.InWarehouse
-
-            "dispatched_by_sender",
-            "dispatched_by_sender_to_pok",
-            "sent_from_source_branch",
-            "sent_from_sorting_center",
-            "unstack_from_customer_service_point",
-            "unstack_from_box_machine" -> Status.InTransit
-
-            "out_for_delivery",
-            "out_for_delivery_to_address" -> Status.OutForDelivery
-
-            "ready_to_pickup",
-            "ready_to_pickup_from_pok",
-            "ready_to_pickup_from_pok_registered",
-            "ready_to_pickup_from_branch",
-            "avizo",
-            "courier_avizo_in_customer_service_point" -> Status.AwaitingPickup
-
-            "pickup_reminder_sent",
-            "pickup_reminder_sent_address" -> Status.PickupTimeEndingSoon
-
-            "readdressed",
-            "redirect_to_box" -> Status.Readdressed
-
-            "return_pickup_confirmation_to_sender" -> Status.Delivered
-            "returned_to_sender" -> Status.ReturnedToSender
-            "delay_in_delivery" -> Status.Delayed
-            "delivered" -> Status.Delivered
-            "other" -> Status.Unknown
-
-            "oversized",
-            "pickup_time_expired",
-            "claimed",
-            "rejected_by_receiver",
-            "undelivered",
-            "undelivered_wrong_address",
-            "undelivered_incomplete_address",
-            "undelivered_unknown_receiver",
-            "undelivered_cod_cash_receiver",
-            "undelivered_no_mailbox",
-            "undelivered_not_live_address",
-            "undelivered_lack_of_access_letterbox",
-            "canceled",
-            "canceled_redirect_to_box",
-            "stack_parcel_pickup_time_expired",
-            "stack_parcel_in_box_machine_pickup_time_expired",
-            "missing" -> Status.DeliveryFailure
-
-            else -> logUnknownStatus("InPost", status)
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val response =
+        try {
+          service.getParcel(trackingId)
+        } catch (e: HttpException) {
+          if (e.code() == 400 || e.code() == 404) throw ParcelNonExistentException()
+          throw e
         }
 
-    private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
-        details.map { item ->
-            ParcelHistoryItem(
-                item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
-                LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
-                item.location ?: item.agency ?: "",
-            )
-        }
-
-    private interface API {
-        @GET("tracking/{trackingId}")
-        @Headers("Accept: application/json")
-        suspend fun getParcel(@Path("trackingId") trackingId: String): TrackingResponse
-    }
-
-    @JsonClass(generateAdapter = true)
-    internal data class TrackingResponse(
-        @Json(name = "tracking_number") val trackingNumber: String,
-        val status: String,
-        @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
+    return Parcel(
+        response.trackingNumber,
+        eventsToHistory(response.trackingDetails),
+        statusToEnum(response.status),
     )
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class TrackingDetail(
-        @Json(name = "origin_status") val originStatus: String?,
-        val status: String,
-        val agency: String?,
-        val location: String?,
-        val datetime: String,
-    )
+  internal fun statusToEnum(status: String): Status =
+      when (status) {
+        "created",
+        "offers_prepared",
+        "offer_selected",
+        "confirmed" -> Status.Preadvice
+
+        "collected_from_sender",
+        "taken_by_courier",
+        "taken_by_courier_from_pok",
+        "taken_by_courier_from_customer_service_point" -> Status.PickedUpByCourier
+
+        "adopted_at_source_branch",
+        "adopted_at_sorting_center",
+        "adopted_at_target_branch",
+        "stack_in_customer_service_point",
+        "stack_in_box_machine" -> Status.InWarehouse
+
+        "dispatched_by_sender",
+        "dispatched_by_sender_to_pok",
+        "sent_from_source_branch",
+        "sent_from_sorting_center",
+        "unstack_from_customer_service_point",
+        "unstack_from_box_machine" -> Status.InTransit
+
+        "out_for_delivery",
+        "out_for_delivery_to_address" -> Status.OutForDelivery
+
+        "ready_to_pickup",
+        "ready_to_pickup_from_pok",
+        "ready_to_pickup_from_pok_registered",
+        "ready_to_pickup_from_branch",
+        "avizo",
+        "courier_avizo_in_customer_service_point" -> Status.AwaitingPickup
+
+        "pickup_reminder_sent",
+        "pickup_reminder_sent_address" -> Status.PickupTimeEndingSoon
+
+        "readdressed",
+        "redirect_to_box" -> Status.Readdressed
+
+        "return_pickup_confirmation_to_sender" -> Status.Delivered
+        "returned_to_sender" -> Status.ReturnedToSender
+        "delay_in_delivery" -> Status.Delayed
+        "delivered" -> Status.Delivered
+        "other" -> Status.Unknown
+
+        "oversized",
+        "pickup_time_expired",
+        "claimed",
+        "rejected_by_receiver",
+        "undelivered",
+        "undelivered_wrong_address",
+        "undelivered_incomplete_address",
+        "undelivered_unknown_receiver",
+        "undelivered_cod_cash_receiver",
+        "undelivered_no_mailbox",
+        "undelivered_not_live_address",
+        "undelivered_lack_of_access_letterbox",
+        "canceled",
+        "canceled_redirect_to_box",
+        "stack_parcel_pickup_time_expired",
+        "stack_parcel_in_box_machine_pickup_time_expired",
+        "missing" -> Status.DeliveryFailure
+
+        else -> logUnknownStatus("InPost", status)
+      }
+
+  private fun eventsToHistory(details: List<TrackingDetail>): List<ParcelHistoryItem> =
+      details.map { item ->
+        ParcelHistoryItem(
+            item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
+            LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+            item.location ?: item.agency ?: "",
+        )
+      }
+
+  private interface API {
+    @GET("tracking/{trackingId}")
+    @Headers("Accept: application/json")
+    suspend fun getParcel(@Path("trackingId") trackingId: String): TrackingResponse
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class TrackingResponse(
+      @Json(name = "tracking_number") val trackingNumber: String,
+      val status: String,
+      @Json(name = "tracking_details") val trackingDetails: List<TrackingDetail>,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class TrackingDetail(
+      @Json(name = "origin_status") val originStatus: String?,
+      val status: String,
+      val agency: String?,
+      val location: String?,
+      val datetime: String,
+  )
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
@@ -13,115 +13,121 @@ import retrofit2.http.POST
 
 // Reverse-engineered from https://emonitoring.poczta-polska.pl
 object PolishPostDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_polish_post
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
+    override val nameResource: Int = R.string.service_polish_post
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
 
-  override fun acceptsFormat(trackingId: String): Boolean {
-    val pocztexRegex = """^PX\d{10}$""".toRegex()
-    return pocztexRegex.matchEntire(trackingId) != null || emsFormat.matchEntire(trackingId) != null
-  }
+    // Confirmed: found a real, publicly indexed tracking link matching this exact
+    // format (emonitoring.poczta-polska.pl/?numer=<real tracking number>).
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            TrackingUrlPattern(
+                """https?://emonitoring\.poczta-polska\.pl/\S*[?&]numer=([A-Za-z0-9]+)"""
+                    .toRegex(RegexOption.IGNORE_CASE)
+            )
+        )
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val locale = LocaleList.getDefault().get(0).language
-    val req = ParcelRequest(trackingId, if (locale == "pl") "X1" else "EN", true)
-    val resp =
-        try {
-          service.getParcel(req)
-        } catch (_: Exception) {
-          throw ParcelNonExistentException()
-        }
+    override fun acceptsFormat(trackingId: String): Boolean {
+        val pocztexRegex = """^PX\d{10}$""".toRegex()
+        return pocztexRegex.matchEntire(trackingId) != null ||
+            emsFormat.matchEntire(trackingId) != null
+    }
 
-    if (resp.mailInfo == null || resp.mailStatus == -1) throw ParcelNonExistentException()
-    val history =
-        resp.mailInfo.events.reversed().map { item ->
-          ParcelHistoryItem(
-              item.name,
-              LocalDateTime.parse(item.time, DateTimeFormatter.ISO_DATE_TIME),
-              if (item.postOffice.description != null)
-                  "${item.postOffice.name}\n${item.postOffice.description.street} ${item.postOffice.description.houseNumber}\n${item.postOffice.description.zipCode} ${item.postOffice.description.city}"
-              else item.postOffice.name)
-        }
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val locale = LocaleList.getDefault().get(0).language
+        val req = ParcelRequest(trackingId, if (locale == "pl") "X1" else "EN", true)
+        val resp =
+            try {
+                service.getParcel(req)
+            } catch (_: Exception) {
+                throw ParcelNonExistentException()
+            }
 
-    val status =
-        when (resp.mailInfo.events.last().code) {
-          "P_NAD",
-          "P_REJ_KN1" -> Status.Preadvice
-          "P_ZWC" -> Status.Customs
-          "P_ZWOLDDOR" -> Status.Customs
-          "P_WPUCPP" -> Status.Customs
-          "P_WZL" -> Status.InTransit
-          "P_WD",
-          "P_WDML" -> Status.OutForDelivery
-          "P_D" -> Status.Delivered
-          "P_A" -> Status.DeliveryFailure
-          "P_KWD" -> Status.AwaitingPickup
-          "P_OWU" -> Status.PickedUp
-          // Post-delivery customs declaration(?)
-          "P_ROZL_CEL" -> Status.Delivered
-          else -> logUnknownStatus("Polish Post", resp.mailInfo.events.last().code)
-        }
+        if (resp.mailInfo == null || resp.mailStatus == -1) throw ParcelNonExistentException()
+        val history =
+            resp.mailInfo.events.reversed().map { item ->
+                ParcelHistoryItem(
+                    item.name,
+                    LocalDateTime.parse(item.time, DateTimeFormatter.ISO_DATE_TIME),
+                    if (item.postOffice.description != null)
+                        "${item.postOffice.name}\n${item.postOffice.description.street} ${item.postOffice.description.houseNumber}\n${item.postOffice.description.zipCode} ${item.postOffice.description.city}"
+                    else item.postOffice.name,
+                )
+            }
 
-    return Parcel(resp.number, history, status)
-  }
+        val status =
+            when (resp.mailInfo.events.last().code) {
+                "P_NAD",
+                "P_REJ_KN1" -> Status.Preadvice
+                "P_ZWC" -> Status.Customs
+                "P_ZWOLDDOR" -> Status.Customs
+                "P_WPUCPP" -> Status.Customs
+                "P_WZL" -> Status.InTransit
+                "P_WD",
+                "P_WDML" -> Status.OutForDelivery
+                "P_D" -> Status.Delivered
+                "P_A" -> Status.DeliveryFailure
+                "P_KWD" -> Status.AwaitingPickup
+                "P_OWU" -> Status.PickedUp
+                // Post-delivery customs declaration(?)
+                "P_ROZL_CEL" -> Status.Delivered
+                else -> logUnknownStatus("Polish Post", resp.mailInfo.events.last().code)
+            }
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://uss.poczta-polska.pl/uss/v1.1/")
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
+        return Parcel(resp.number, history, status)
+    }
 
-  private val service = retrofit.create(API::class.java)
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://uss.poczta-polska.pl/uss/v1.1/")
+            .client(api_client)
+            .addConverterFactory(api_factory)
+            .build()
 
-  private const val API_KEY =
-      "BiGwVG2XHvXY+kPwJVPA8gnKchOFsyy39Thkyb1wAiWcKLQ1ICyLiCrxj1+vVGC+kQk3k0b74qkmt5/qVIzo7lTfXhfgJ72Iyzz05wH2XZI6AgXVDciX7G2jLCdoOEM6XegPsMJChiouWS2RZuf3eOXpK5RPl8Sy4pWj+b07MLg=.Mjg0Q0NFNzM0RTBERTIwOTNFOUYxNkYxMUY1NDZGMTA0NDMwQUIyRjg4REUxMjk5NDAyMkQ0N0VCNDgwNTc1NA==.b24415d1b30a456cb8ba187b34cb6a86"
+    private val service = retrofit.create(API::class.java)
 
-  private interface API {
-    @POST("tracking/checkmailex")
-    @Headers("Api_key: $API_KEY")
-    suspend fun getParcel(@Body data: ParcelRequest): ParcelResponse
-  }
+    private const val API_KEY =
+        "BiGwVG2XHvXY+kPwJVPA8gnKchOFsyy39Thkyb1wAiWcKLQ1ICyLiCrxj1+vVGC+kQk3k0b74qkmt5/qVIzo7lTfXhfgJ72Iyzz05wH2XZI6AgXVDciX7G2jLCdoOEM6XegPsMJChiouWS2RZuf3eOXpK5RPl8Sy4pWj+b07MLg=.Mjg0Q0NFNzM0RTBERTIwOTNFOUYxNkYxMUY1NDZGMTA0NDMwQUIyRjg4REUxMjk5NDAyMkQ0N0VCNDgwNTc1NA==.b24415d1b30a456cb8ba187b34cb6a86"
 
-  @JsonClass(generateAdapter = true)
-  internal data class ParcelRequest(
-      val number: String,
-      val language: String, // X1 - Polish(?), EN - English
-      val addPostOfficeInfo: Boolean,
-  )
+    private interface API {
+        @POST("tracking/checkmailex")
+        @Headers("Api_key: $API_KEY")
+        suspend fun getParcel(@Body data: ParcelRequest): ParcelResponse
+    }
 
-  @JsonClass(generateAdapter = true)
-  internal data class ParcelResponse(
-      val mailInfo: MailInfo?,
-      val mailStatus: Int,
-      val number: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ParcelRequest(
+        val number: String,
+        val language: String, // X1 - Polish(?), EN - English
+        val addPostOfficeInfo: Boolean,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class MailInfo(
-      val number: String,
-      val events: List<Event>,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ParcelResponse(
+        val mailInfo: MailInfo?,
+        val mailStatus: Int,
+        val number: String,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class Event(
-      val code: String,
-      val name: String,
-      val postOffice: PostOffice,
-      val time: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class MailInfo(val number: String, val events: List<Event>)
 
-  @JsonClass(generateAdapter = true)
-  internal data class PostOffice(
-      val name: String,
-      val description: PostOfficeDescription?,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Event(
+        val code: String,
+        val name: String,
+        val postOffice: PostOffice,
+        val time: String,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class PostOfficeDescription(
-      val city: String,
-      val houseNumber: String,
-      val street: String,
-      val zipCode: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class PostOffice(val name: String, val description: PostOfficeDescription?)
+
+    @JsonClass(generateAdapter = true)
+    internal data class PostOfficeDescription(
+        val city: String,
+        val houseNumber: String,
+        val street: String,
+        val zipCode: String,
+    )
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
@@ -13,121 +13,118 @@ import retrofit2.http.POST
 
 // Reverse-engineered from https://emonitoring.poczta-polska.pl
 object PolishPostDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_polish_post
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
+  override val nameResource: Int = R.string.service_polish_post
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
 
-    // Confirmed: found a real, publicly indexed tracking link matching this exact
-    // format (emonitoring.poczta-polska.pl/?numer=<real tracking number>).
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            TrackingUrlPattern(
-                """https?://emonitoring\.poczta-polska\.pl/\S*[?&]numer=([A-Za-z0-9]+)"""
-                    .toRegex(RegexOption.IGNORE_CASE)
-            )
-        )
+  // Confirmed: found a real, publicly indexed tracking link matching this exact
+  // format (emonitoring.poczta-polska.pl/?numer=<real tracking number>).
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://emonitoring\.poczta-polska\.pl/\S*[?&]numer=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)))
 
-    override fun acceptsFormat(trackingId: String): Boolean {
-        val pocztexRegex = """^PX\d{10}$""".toRegex()
-        return pocztexRegex.matchEntire(trackingId) != null ||
-            emsFormat.matchEntire(trackingId) != null
-    }
+  override fun acceptsFormat(trackingId: String): Boolean {
+    val pocztexRegex = """^PX\d{10}$""".toRegex()
+    return pocztexRegex.matchEntire(trackingId) != null || emsFormat.matchEntire(trackingId) != null
+  }
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val locale = LocaleList.getDefault().get(0).language
-        val req = ParcelRequest(trackingId, if (locale == "pl") "X1" else "EN", true)
-        val resp =
-            try {
-                service.getParcel(req)
-            } catch (_: Exception) {
-                throw ParcelNonExistentException()
-            }
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val locale = LocaleList.getDefault().get(0).language
+    val req = ParcelRequest(trackingId, if (locale == "pl") "X1" else "EN", true)
+    val resp =
+        try {
+          service.getParcel(req)
+        } catch (_: Exception) {
+          throw ParcelNonExistentException()
+        }
 
-        if (resp.mailInfo == null || resp.mailStatus == -1) throw ParcelNonExistentException()
-        val history =
-            resp.mailInfo.events.reversed().map { item ->
-                ParcelHistoryItem(
-                    item.name,
-                    LocalDateTime.parse(item.time, DateTimeFormatter.ISO_DATE_TIME),
-                    if (item.postOffice.description != null)
-                        "${item.postOffice.name}\n${item.postOffice.description.street} ${item.postOffice.description.houseNumber}\n${item.postOffice.description.zipCode} ${item.postOffice.description.city}"
-                    else item.postOffice.name,
-                )
-            }
+    if (resp.mailInfo == null || resp.mailStatus == -1) throw ParcelNonExistentException()
+    val history =
+        resp.mailInfo.events.reversed().map { item ->
+          ParcelHistoryItem(
+              item.name,
+              LocalDateTime.parse(item.time, DateTimeFormatter.ISO_DATE_TIME),
+              if (item.postOffice.description != null)
+                  "${item.postOffice.name}\n${item.postOffice.description.street} ${item.postOffice.description.houseNumber}\n${item.postOffice.description.zipCode} ${item.postOffice.description.city}"
+              else item.postOffice.name,
+          )
+        }
 
-        val status =
-            when (resp.mailInfo.events.last().code) {
-                "P_NAD",
-                "P_REJ_KN1" -> Status.Preadvice
-                "P_ZWC" -> Status.Customs
-                "P_ZWOLDDOR" -> Status.Customs
-                "P_WPUCPP" -> Status.Customs
-                "P_WZL" -> Status.InTransit
-                "P_WD",
-                "P_WDML" -> Status.OutForDelivery
-                "P_D" -> Status.Delivered
-                "P_A" -> Status.DeliveryFailure
-                "P_KWD" -> Status.AwaitingPickup
-                "P_OWU" -> Status.PickedUp
-                // Post-delivery customs declaration(?)
-                "P_ROZL_CEL" -> Status.Delivered
-                else -> logUnknownStatus("Polish Post", resp.mailInfo.events.last().code)
-            }
+    val status =
+        when (resp.mailInfo.events.last().code) {
+          "P_NAD",
+          "P_REJ_KN1" -> Status.Preadvice
+          "P_ZWC" -> Status.Customs
+          "P_ZWOLDDOR" -> Status.Customs
+          "P_WPUCPP" -> Status.Customs
+          "P_WZL" -> Status.InTransit
+          "P_WD",
+          "P_WDML" -> Status.OutForDelivery
+          "P_D" -> Status.Delivered
+          "P_A" -> Status.DeliveryFailure
+          "P_KWD" -> Status.AwaitingPickup
+          "P_OWU" -> Status.PickedUp
+          // Post-delivery customs declaration(?)
+          "P_ROZL_CEL" -> Status.Delivered
+          else -> logUnknownStatus("Polish Post", resp.mailInfo.events.last().code)
+        }
 
-        return Parcel(resp.number, history, status)
-    }
+    return Parcel(resp.number, history, status)
+  }
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://uss.poczta-polska.pl/uss/v1.1/")
-            .client(api_client)
-            .addConverterFactory(api_factory)
-            .build()
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://uss.poczta-polska.pl/uss/v1.1/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
 
-    private val service = retrofit.create(API::class.java)
+  private val service = retrofit.create(API::class.java)
 
-    private const val API_KEY =
-        "BiGwVG2XHvXY+kPwJVPA8gnKchOFsyy39Thkyb1wAiWcKLQ1ICyLiCrxj1+vVGC+kQk3k0b74qkmt5/qVIzo7lTfXhfgJ72Iyzz05wH2XZI6AgXVDciX7G2jLCdoOEM6XegPsMJChiouWS2RZuf3eOXpK5RPl8Sy4pWj+b07MLg=.Mjg0Q0NFNzM0RTBERTIwOTNFOUYxNkYxMUY1NDZGMTA0NDMwQUIyRjg4REUxMjk5NDAyMkQ0N0VCNDgwNTc1NA==.b24415d1b30a456cb8ba187b34cb6a86"
+  private const val API_KEY =
+      "BiGwVG2XHvXY+kPwJVPA8gnKchOFsyy39Thkyb1wAiWcKLQ1ICyLiCrxj1+vVGC+kQk3k0b74qkmt5/qVIzo7lTfXhfgJ72Iyzz05wH2XZI6AgXVDciX7G2jLCdoOEM6XegPsMJChiouWS2RZuf3eOXpK5RPl8Sy4pWj+b07MLg=.Mjg0Q0NFNzM0RTBERTIwOTNFOUYxNkYxMUY1NDZGMTA0NDMwQUIyRjg4REUxMjk5NDAyMkQ0N0VCNDgwNTc1NA==.b24415d1b30a456cb8ba187b34cb6a86"
 
-    private interface API {
-        @POST("tracking/checkmailex")
-        @Headers("Api_key: $API_KEY")
-        suspend fun getParcel(@Body data: ParcelRequest): ParcelResponse
-    }
+  private interface API {
+    @POST("tracking/checkmailex")
+    @Headers("Api_key: $API_KEY")
+    suspend fun getParcel(@Body data: ParcelRequest): ParcelResponse
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class ParcelRequest(
-        val number: String,
-        val language: String, // X1 - Polish(?), EN - English
-        val addPostOfficeInfo: Boolean,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelRequest(
+      val number: String,
+      val language: String, // X1 - Polish(?), EN - English
+      val addPostOfficeInfo: Boolean,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class ParcelResponse(
-        val mailInfo: MailInfo?,
-        val mailStatus: Int,
-        val number: String,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelResponse(
+      val mailInfo: MailInfo?,
+      val mailStatus: Int,
+      val number: String,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class MailInfo(val number: String, val events: List<Event>)
+  @JsonClass(generateAdapter = true)
+  internal data class MailInfo(val number: String, val events: List<Event>)
 
-    @JsonClass(generateAdapter = true)
-    internal data class Event(
-        val code: String,
-        val name: String,
-        val postOffice: PostOffice,
-        val time: String,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Event(
+      val code: String,
+      val name: String,
+      val postOffice: PostOffice,
+      val time: String,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class PostOffice(val name: String, val description: PostOfficeDescription?)
+  @JsonClass(generateAdapter = true)
+  internal data class PostOffice(val name: String, val description: PostOfficeDescription?)
 
-    @JsonClass(generateAdapter = true)
-    internal data class PostOfficeDescription(
-        val city: String,
-        val houseNumber: String,
-        val street: String,
-        val zipCode: String,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class PostOfficeDescription(
+      val city: String,
+      val houseNumber: String,
+      val street: String,
+      val zipCode: String,
+  )
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNLDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNLDeliveryService.kt
@@ -13,415 +13,411 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 object PostNLDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_postnl
-    override val acceptsPostCode: Boolean = true
-    override val requiresPostCode: Boolean = true
+  override val nameResource: Int = R.string.service_postnl
+  override val acceptsPostCode: Boolean = true
+  override val requiresPostCode: Boolean = true
 
-    // Confirmed: verified against real link
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            TrackingUrlPattern(
-                urlRegex =
-                    """https?://jouw\.postnl\.nl/track-and-trace/([A-Za-z0-9]+)-"""
-                        .toRegex(RegexOption.IGNORE_CASE),
-                postalCodeRegex =
-                    """track-and-trace/[A-Za-z0-9]+-[A-Za-z]{2}-([A-Za-z0-9]+)"""
-                        .toRegex(RegexOption.IGNORE_CASE),
-            )
-        )
+  // Confirmed: verified against real link
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              urlRegex =
+                  """https?://jouw\.postnl\.nl/track-and-trace/([A-Za-z0-9]+)-"""
+                      .toRegex(RegexOption.IGNORE_CASE),
+              postalCodeRegex =
+                  """track-and-trace/[A-Za-z0-9]+-[A-Za-z]{2}-([A-Za-z0-9]+)"""
+                      .toRegex(RegexOption.IGNORE_CASE),
+          ))
 
-    private val retrofit: Retrofit
+  private val retrofit: Retrofit
 
-    init {
-        val apiMoshi: Moshi =
-            Moshi.Builder()
-                .add(LocalDateTime::class.java, Rfc3339LocalDateTimeJsonAdapter())
-                .build()
-        val apiFactory = MoshiConverterFactory.create(apiMoshi)
+  init {
+    val apiMoshi: Moshi =
+        Moshi.Builder().add(LocalDateTime::class.java, Rfc3339LocalDateTimeJsonAdapter()).build()
+    val apiFactory = MoshiConverterFactory.create(apiMoshi)
 
-        this.retrofit =
-            Retrofit.Builder()
-                .baseUrl("https://jouw.postnl.nl/track-and-trace/api/")
-                .client(api_client)
-                .addConverterFactory(apiFactory)
-                .build()
-    }
+    this.retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://jouw.postnl.nl/track-and-trace/api/")
+            .client(api_client)
+            .addConverterFactory(apiFactory)
+            .build()
+  }
 
-    private val service = retrofit.create(API::class.java)
+  private val service = retrofit.create(API::class.java)
 
-    override suspend fun getParcel(
-        trackingId: String,
-        postCode: String?,
-    ): dev.itsvic.parceltracker.api.Parcel {
-        val resp =
-            try {
-                // TODO: support deliveries to countries other than Netherlands
-                service.getParcel("${trackingId}-NL-${postCode}")
-            } catch (_: HttpException) {
-                throw ParcelNonExistentException()
-            }
-
-        val parcel = resp.colli[trackingId] ?: throw ParcelNonExistentException()
-
-        var etaHistoryItem: ParcelHistoryItem? = null
-        if (parcel.eta != null && parcel.eta.start != null && parcel.eta.end != null) {
-            etaHistoryItem =
-                ParcelHistoryItem(
-                    "Package Expected between ${parcel.eta.start} ${parcel.eta.end}",
-                    parcel.eta.start,
-                    "",
-                )
+  override suspend fun getParcel(
+      trackingId: String,
+      postCode: String?,
+  ): dev.itsvic.parceltracker.api.Parcel {
+    val resp =
+        try {
+          // TODO: support deliveries to countries other than Netherlands
+          service.getParcel("${trackingId}-NL-${postCode}")
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
         }
 
-        val observations =
-            parcel.analyticsInfo.allObservations.sortedByDescending { it.observationDate }
+    val parcel = resp.colli[trackingId] ?: throw ParcelNonExistentException()
 
-        val observationsHistoryItems =
-            observations
-                .filter { (_, _, description) -> description != null }
-                .map { (observationDate, observationCode, description) ->
-                    ParcelHistoryItem(description ?: "", observationDate, location = "")
-                }
-
-        val currentStatus =
-            observations.firstOrNull { it.status() != Status.Unknown }?.status() ?: Status.Unknown
-
-        val history = (etaHistoryItem?.let { listOf(it) } ?: emptyList()) + observationsHistoryItems
-        return Parcel(trackingId, history = history, currentStatus)
+    var etaHistoryItem: ParcelHistoryItem? = null
+    if (parcel.eta != null && parcel.eta.start != null && parcel.eta.end != null) {
+      etaHistoryItem =
+          ParcelHistoryItem(
+              "Package Expected between ${parcel.eta.start} ${parcel.eta.end}",
+              parcel.eta.start,
+              "",
+          )
     }
 
-    private interface API {
-        @GET("trackAndTrace/{parcel}")
-        suspend fun getParcel(
-            @Path("parcel") parcel: String,
-            @Query("language") lang: String = "en",
-        ): GetParcelResponse
-    }
+    val observations =
+        parcel.analyticsInfo.allObservations.sortedByDescending { it.observationDate }
+
+    val observationsHistoryItems =
+        observations
+            .filter { (_, _, description) -> description != null }
+            .map { (observationDate, observationCode, description) ->
+              ParcelHistoryItem(description ?: "", observationDate, location = "")
+            }
+
+    val currentStatus =
+        observations.firstOrNull { it.status() != Status.Unknown }?.status() ?: Status.Unknown
+
+    val history = (etaHistoryItem?.let { listOf(it) } ?: emptyList()) + observationsHistoryItems
+    return Parcel(trackingId, history = history, currentStatus)
+  }
+
+  private interface API {
+    @GET("trackAndTrace/{parcel}")
+    suspend fun getParcel(
+        @Path("parcel") parcel: String,
+        @Query("language") lang: String = "en",
+    ): GetParcelResponse
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class GetParcelResponse(val colli: Map<String, Parcel>)
+
+  @JsonClass(generateAdapter = true)
+  internal data class Parcel(
+      val analyticsInfo: AnalyticsInfo,
+      val observations: List<Observation>,
+      val eta: Eta?,
+  ) {
+    @JsonClass(generateAdapter = true)
+    internal data class AnalyticsInfo(val allObservations: List<Observation>)
 
     @JsonClass(generateAdapter = true)
-    internal data class GetParcelResponse(val colli: Map<String, Parcel>)
+    internal data class Eta(
+        val type: String,
+        val start: LocalDateTime?,
+        val end: LocalDateTime?,
+    )
 
     @JsonClass(generateAdapter = true)
-    internal data class Parcel(
-        val analyticsInfo: AnalyticsInfo,
-        val observations: List<Observation>,
-        val eta: Eta?,
+    internal data class Observation(
+        val observationDate: LocalDateTime,
+        val observationCode: String,
+        val description: String?,
     ) {
-        @JsonClass(generateAdapter = true)
-        internal data class AnalyticsInfo(val allObservations: List<Observation>)
 
-        @JsonClass(generateAdapter = true)
-        internal data class Eta(
-            val type: String,
-            val start: LocalDateTime?,
-            val end: LocalDateTime?,
-        )
-
-        @JsonClass(generateAdapter = true)
-        internal data class Observation(
-            val observationDate: LocalDateTime,
-            val observationCode: String,
-            val description: String?,
-        ) {
-
-            fun status(): Status {
-                return eventCodeToStatus(this.observationCode)
-            }
-        }
+      fun status(): Status {
+        return eventCodeToStatus(this.observationCode)
+      }
     }
+  }
 
-    // from: https://developer.postnl.nl/docs/#/http/reference-data/t-t-status-codes/event-codes
-    private fun eventCodeToStatus(eventCode: String): Status {
-        return when (eventCode) {
-            "A01",
-            "A10",
-            "A71",
-            "F01",
-            "J93",
-            "M03",
-            "X80",
-            "X81" -> Status.Preadvice // "01, Zending voorgemeld"
-            "B01",
-            "X40" -> Status.InTransit // "02, Zending in ontvangst genomen"
-            "B04" -> Status.PickedUpByCourier // "03, Zending afgehaald"
-            "Z80" -> Status.PickedUp
-            "D02",
-            "D03",
-            "D04",
-            "D05",
-            "D06",
-            "D07",
-            "D09",
-            "D40",
-            "D41",
-            "H31",
-            "X42",
-            "X43",
-            "Y80",
-            "Y81" -> Status.Unknown // "04, Zending niet afgehaald"
-            "A08",
-            "A09",
-            "A11",
-            "A12",
-            "A13",
-            "A27",
-            "A28",
-            "A29",
-            "A30",
-            "A31",
-            "A32",
-            "A34",
-            "A35",
-            "A42",
-            "A43",
-            "A99",
-            "J01",
-            "J06",
-            "J07",
-            "J09",
-            "J10",
-            "J14",
-            "J16",
-            "J17",
-            "J22",
-            "J24",
-            "J26",
-            "J27",
-            "J28",
-            "J33",
-            "J36",
-            "J61",
-            "J90",
-            "Q12",
-            "Q13",
-            "R01",
-            "R06",
-            "X01",
-            "X02",
-            "X07",
-            "X08",
-            "X11",
-            "X14",
-            "X17",
-            "X20",
-            "X21",
-            "X22",
-            "X50",
-            "X51",
-            "X68",
-            "Y23",
-            "Y24",
-            "Y33",
-            "Y35",
-            "Y60",
-            "Y61",
-            "Y62" -> Status.InTransit // "05, Zending gesorteerd"
-            "D08",
-            "H10",
-            "K01",
-            "K02",
-            "K03",
-            "K30",
-            "K92",
-            "V01",
-            "V06",
-            "Y07" -> Status.InWarehouse // "06, Zending niet gesorteerd"
-            "H32",
-            "H35",
-            "J05",
-            "J08",
-            "J29",
-            "J39",
-            "J41",
-            "J42",
-            "J45",
-            "J47",
-            "J48",
-            "J55",
-            "J94",
-            "J95",
-            "K14",
-            "K15",
-            "K70",
-            "Q15",
-            "S05",
-            "T02",
-            "X04",
-            "X06",
-            "X19",
-            "X55",
-            "Y05" -> Status.InTransit // "07, Zending in distributieproces"
-            "H01",
-            "H02",
-            "H03",
-            "H04",
-            "H05",
-            "H07",
-            "H08",
-            "H09",
-            "H12",
-            "H20",
-            "H22",
-            "H24",
-            "H34",
-            "H36",
-            "H38",
-            "H51",
-            "H52",
-            "J92",
-            "K16",
-            "K41",
-            "K43",
-            "Y01",
-            "Y02",
-            "Y03",
-            "Y04",
-            "Y08",
-            "Y09",
-            "Y10",
-            "Y11",
-            "Y12",
-            "Y13",
-            "Y14",
-            "Y15",
-            "Y16",
-            "Y17",
-            "Y18",
-            "Y19",
-            "Y20",
-            "Y21",
-            "Y22",
-            "Y30",
-            "Y31",
-            "Y32",
-            "Y36",
-            "Y38",
-            "Y39",
-            "Y40",
-            "Y41",
-            "Y42",
-            "Y43",
-            "Y44",
-            "Y50",
-            "Y71" -> Status.DeliveryFailure // "08, Zending niet afgeleverd"
-            "J59",
-            "X30",
-            "X60",
-            "X61",
-            "X62",
-            "X63",
-            "X64",
-            "X65",
-            "X66",
-            "Y25",
-            "Y29" -> Status.CustomsHeld // "09, Zending bij douane"
-            "I01",
-            "I03",
-            "I05",
-            "I06",
-            "I07",
-            "I09",
-            "I10",
-            "I11",
-            "I12",
-            "I22",
-            "I23",
-            "J63",
-            "J91",
-            "K91",
-            "X24",
-            "Y26",
-            "Z01",
-            "Z02",
-            "Z03",
-            "Z04",
-            "Z05",
-            "Z06",
-            "Z08",
-            "Z09" -> Status.Delivered // "11, Zending afgeleverd"
-            "I08",
-            "J02",
-            "J12",
-            "J23",
-            "J52",
-            "X05" -> Status.AwaitingPickup // "12, Zending beschikbaar op afhaallocatie"
-            "A20",
-            "A21",
-            "A22",
-            "Q02",
-            "X03" -> Status.Preadvice // "13, Voorgemeld: nog niet aangenomen"
-            "M01" -> Status.Preadvice // "14, Voorgemeld: definitief niet aangenomen"
-            "G03" -> Status.PickedUpByCourier // "15, Manco collectie"
-            "G01",
-            "G02",
-            "G05" -> Status.InWarehouse // "16, Manco sortering"
-            "H23",
-            "K90" -> Status.OutForDelivery // "17, Manco distributie"
-            "F03",
-            "F04",
-            "F05",
-            "F06",
-            "F07",
-            "F08",
-            "F10" -> Status.Destroyed // "19, Zending afgekeurd"
-            "A76",
-            "X10",
-            "X67" -> Status.Customs // "20, Zending in inklaringsproces"
-            "V02",
-            "V03",
-            "V04",
-            "V11",
-            "V12",
-            "V13",
-            "V21",
-            "V22",
-            "V23",
-            "V31",
-            "V50" -> Status.InWarehouse // "21, Zending in voorraad"
-            "I02" -> Status.PickedUp // "22, Zending afgehaald van Postkantoor"
-            "C01" -> Status.Preadvice // "23, Afhaalopdracht gecollecteerd"
-            "H16",
-            "H25" -> Status.ReturningToSender // "27, Retour Onbestelbaar"
-            "Y37" -> Status.ReturningToSender // "28, Retour Foutieve aflevercode"
-            "A72",
-            "A74",
-            "A75",
-            "X15" ->
-                Status.CustomsSuccess // "31, Zending klaar voor transport naar land van bestemming"
-            "A41",
-            "A46",
-            "A73",
-            "A94",
-            "B06",
-            "C02",
-            "H15",
-            "H17",
-            "H18",
-            "H30",
-            "J56",
-            "J80",
-            "K25",
-            "K71",
-            "P20",
-            "P21",
-            "P22",
-            "P23",
-            "P24",
-            "Q14",
-            "Q16",
-            "Q17",
-            "Q18",
-            "Q19",
-            "X16",
-            "X52",
-            "Y45",
-            "Y46",
-            "Y47",
-            "Y48",
-            "Y64",
-            "Y65",
-            "Y66" -> Status.Unknown // "99, Niet van toepassing"'
-            else -> logUnknownStatus("PostNL", "unknown event code: $eventCode")
-        }
+  // from: https://developer.postnl.nl/docs/#/http/reference-data/t-t-status-codes/event-codes
+  private fun eventCodeToStatus(eventCode: String): Status {
+    return when (eventCode) {
+      "A01",
+      "A10",
+      "A71",
+      "F01",
+      "J93",
+      "M03",
+      "X80",
+      "X81" -> Status.Preadvice // "01, Zending voorgemeld"
+      "B01",
+      "X40" -> Status.InTransit // "02, Zending in ontvangst genomen"
+      "B04" -> Status.PickedUpByCourier // "03, Zending afgehaald"
+      "Z80" -> Status.PickedUp
+      "D02",
+      "D03",
+      "D04",
+      "D05",
+      "D06",
+      "D07",
+      "D09",
+      "D40",
+      "D41",
+      "H31",
+      "X42",
+      "X43",
+      "Y80",
+      "Y81" -> Status.Unknown // "04, Zending niet afgehaald"
+      "A08",
+      "A09",
+      "A11",
+      "A12",
+      "A13",
+      "A27",
+      "A28",
+      "A29",
+      "A30",
+      "A31",
+      "A32",
+      "A34",
+      "A35",
+      "A42",
+      "A43",
+      "A99",
+      "J01",
+      "J06",
+      "J07",
+      "J09",
+      "J10",
+      "J14",
+      "J16",
+      "J17",
+      "J22",
+      "J24",
+      "J26",
+      "J27",
+      "J28",
+      "J33",
+      "J36",
+      "J61",
+      "J90",
+      "Q12",
+      "Q13",
+      "R01",
+      "R06",
+      "X01",
+      "X02",
+      "X07",
+      "X08",
+      "X11",
+      "X14",
+      "X17",
+      "X20",
+      "X21",
+      "X22",
+      "X50",
+      "X51",
+      "X68",
+      "Y23",
+      "Y24",
+      "Y33",
+      "Y35",
+      "Y60",
+      "Y61",
+      "Y62" -> Status.InTransit // "05, Zending gesorteerd"
+      "D08",
+      "H10",
+      "K01",
+      "K02",
+      "K03",
+      "K30",
+      "K92",
+      "V01",
+      "V06",
+      "Y07" -> Status.InWarehouse // "06, Zending niet gesorteerd"
+      "H32",
+      "H35",
+      "J05",
+      "J08",
+      "J29",
+      "J39",
+      "J41",
+      "J42",
+      "J45",
+      "J47",
+      "J48",
+      "J55",
+      "J94",
+      "J95",
+      "K14",
+      "K15",
+      "K70",
+      "Q15",
+      "S05",
+      "T02",
+      "X04",
+      "X06",
+      "X19",
+      "X55",
+      "Y05" -> Status.InTransit // "07, Zending in distributieproces"
+      "H01",
+      "H02",
+      "H03",
+      "H04",
+      "H05",
+      "H07",
+      "H08",
+      "H09",
+      "H12",
+      "H20",
+      "H22",
+      "H24",
+      "H34",
+      "H36",
+      "H38",
+      "H51",
+      "H52",
+      "J92",
+      "K16",
+      "K41",
+      "K43",
+      "Y01",
+      "Y02",
+      "Y03",
+      "Y04",
+      "Y08",
+      "Y09",
+      "Y10",
+      "Y11",
+      "Y12",
+      "Y13",
+      "Y14",
+      "Y15",
+      "Y16",
+      "Y17",
+      "Y18",
+      "Y19",
+      "Y20",
+      "Y21",
+      "Y22",
+      "Y30",
+      "Y31",
+      "Y32",
+      "Y36",
+      "Y38",
+      "Y39",
+      "Y40",
+      "Y41",
+      "Y42",
+      "Y43",
+      "Y44",
+      "Y50",
+      "Y71" -> Status.DeliveryFailure // "08, Zending niet afgeleverd"
+      "J59",
+      "X30",
+      "X60",
+      "X61",
+      "X62",
+      "X63",
+      "X64",
+      "X65",
+      "X66",
+      "Y25",
+      "Y29" -> Status.CustomsHeld // "09, Zending bij douane"
+      "I01",
+      "I03",
+      "I05",
+      "I06",
+      "I07",
+      "I09",
+      "I10",
+      "I11",
+      "I12",
+      "I22",
+      "I23",
+      "J63",
+      "J91",
+      "K91",
+      "X24",
+      "Y26",
+      "Z01",
+      "Z02",
+      "Z03",
+      "Z04",
+      "Z05",
+      "Z06",
+      "Z08",
+      "Z09" -> Status.Delivered // "11, Zending afgeleverd"
+      "I08",
+      "J02",
+      "J12",
+      "J23",
+      "J52",
+      "X05" -> Status.AwaitingPickup // "12, Zending beschikbaar op afhaallocatie"
+      "A20",
+      "A21",
+      "A22",
+      "Q02",
+      "X03" -> Status.Preadvice // "13, Voorgemeld: nog niet aangenomen"
+      "M01" -> Status.Preadvice // "14, Voorgemeld: definitief niet aangenomen"
+      "G03" -> Status.PickedUpByCourier // "15, Manco collectie"
+      "G01",
+      "G02",
+      "G05" -> Status.InWarehouse // "16, Manco sortering"
+      "H23",
+      "K90" -> Status.OutForDelivery // "17, Manco distributie"
+      "F03",
+      "F04",
+      "F05",
+      "F06",
+      "F07",
+      "F08",
+      "F10" -> Status.Destroyed // "19, Zending afgekeurd"
+      "A76",
+      "X10",
+      "X67" -> Status.Customs // "20, Zending in inklaringsproces"
+      "V02",
+      "V03",
+      "V04",
+      "V11",
+      "V12",
+      "V13",
+      "V21",
+      "V22",
+      "V23",
+      "V31",
+      "V50" -> Status.InWarehouse // "21, Zending in voorraad"
+      "I02" -> Status.PickedUp // "22, Zending afgehaald van Postkantoor"
+      "C01" -> Status.Preadvice // "23, Afhaalopdracht gecollecteerd"
+      "H16",
+      "H25" -> Status.ReturningToSender // "27, Retour Onbestelbaar"
+      "Y37" -> Status.ReturningToSender // "28, Retour Foutieve aflevercode"
+      "A72",
+      "A74",
+      "A75",
+      "X15" -> Status.CustomsSuccess // "31, Zending klaar voor transport naar land van bestemming"
+      "A41",
+      "A46",
+      "A73",
+      "A94",
+      "B06",
+      "C02",
+      "H15",
+      "H17",
+      "H18",
+      "H30",
+      "J56",
+      "J80",
+      "K25",
+      "K71",
+      "P20",
+      "P21",
+      "P22",
+      "P23",
+      "P24",
+      "Q14",
+      "Q16",
+      "Q17",
+      "Q18",
+      "Q19",
+      "X16",
+      "X52",
+      "Y45",
+      "Y46",
+      "Y47",
+      "Y48",
+      "Y64",
+      "Y65",
+      "Y66" -> Status.Unknown // "99, Niet van toepassing"'
+      else -> logUnknownStatus("PostNL", "unknown event code: $eventCode")
     }
+  }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNLDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNLDeliveryService.kt
@@ -13,397 +13,415 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 object PostNLDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_postnl
-  override val acceptsPostCode: Boolean = true
-  override val requiresPostCode: Boolean = true
+    override val nameResource: Int = R.string.service_postnl
+    override val acceptsPostCode: Boolean = true
+    override val requiresPostCode: Boolean = true
 
-  private val retrofit: Retrofit
+    // Confirmed: verified against real link
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            TrackingUrlPattern(
+                urlRegex =
+                    """https?://jouw\.postnl\.nl/track-and-trace/([A-Za-z0-9]+)-"""
+                        .toRegex(RegexOption.IGNORE_CASE),
+                postalCodeRegex =
+                    """track-and-trace/[A-Za-z0-9]+-[A-Za-z]{2}-([A-Za-z0-9]+)"""
+                        .toRegex(RegexOption.IGNORE_CASE),
+            )
+        )
 
-  init {
-    val apiMoshi: Moshi =
-        Moshi.Builder().add(LocalDateTime::class.java, Rfc3339LocalDateTimeJsonAdapter()).build()
-    val apiFactory = MoshiConverterFactory.create(apiMoshi)
+    private val retrofit: Retrofit
 
-    this.retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://jouw.postnl.nl/track-and-trace/api/")
-            .client(api_client)
-            .addConverterFactory(apiFactory)
-            .build()
-  }
+    init {
+        val apiMoshi: Moshi =
+            Moshi.Builder()
+                .add(LocalDateTime::class.java, Rfc3339LocalDateTimeJsonAdapter())
+                .build()
+        val apiFactory = MoshiConverterFactory.create(apiMoshi)
 
-  private val service = retrofit.create(API::class.java)
-
-  override suspend fun getParcel(
-      trackingId: String,
-      postCode: String?
-  ): dev.itsvic.parceltracker.api.Parcel {
-    val resp =
-        try {
-          // TODO: support deliveries to countries other than Netherlands
-          service.getParcel("${trackingId}-NL-${postCode}")
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
-        }
-
-    val parcel = resp.colli[trackingId] ?: throw ParcelNonExistentException()
-
-    var etaHistoryItem: ParcelHistoryItem? = null
-    if (parcel.eta != null && parcel.eta.start != null && parcel.eta.end != null) {
-      etaHistoryItem =
-          ParcelHistoryItem(
-              "Package Expected between ${parcel.eta.start} ${parcel.eta.end}",
-              parcel.eta.start,
-              "",
-          )
+        this.retrofit =
+            Retrofit.Builder()
+                .baseUrl("https://jouw.postnl.nl/track-and-trace/api/")
+                .client(api_client)
+                .addConverterFactory(apiFactory)
+                .build()
     }
 
-    val observations =
-        parcel.analyticsInfo.allObservations.sortedByDescending { it.observationDate }
+    private val service = retrofit.create(API::class.java)
 
-    val observationsHistoryItems =
-        observations
-            .filter { (_, _, description) -> description != null }
-            .map { (observationDate, observationCode, description) ->
-              ParcelHistoryItem(description ?: "", observationDate, location = "")
+    override suspend fun getParcel(
+        trackingId: String,
+        postCode: String?,
+    ): dev.itsvic.parceltracker.api.Parcel {
+        val resp =
+            try {
+                // TODO: support deliveries to countries other than Netherlands
+                service.getParcel("${trackingId}-NL-${postCode}")
+            } catch (_: HttpException) {
+                throw ParcelNonExistentException()
             }
 
-    val currentStatus =
-        observations.firstOrNull { it.status() != Status.Unknown }?.status() ?: Status.Unknown
+        val parcel = resp.colli[trackingId] ?: throw ParcelNonExistentException()
 
-    val history = (etaHistoryItem?.let { listOf(it) } ?: emptyList()) + observationsHistoryItems
-    return Parcel(trackingId, history = history, currentStatus)
-  }
+        var etaHistoryItem: ParcelHistoryItem? = null
+        if (parcel.eta != null && parcel.eta.start != null && parcel.eta.end != null) {
+            etaHistoryItem =
+                ParcelHistoryItem(
+                    "Package Expected between ${parcel.eta.start} ${parcel.eta.end}",
+                    parcel.eta.start,
+                    "",
+                )
+        }
 
-  private interface API {
-    @GET("trackAndTrace/{parcel}")
-    suspend fun getParcel(
-        @Path("parcel") parcel: String,
-        @Query("language") lang: String = "en"
-    ): GetParcelResponse
-  }
+        val observations =
+            parcel.analyticsInfo.allObservations.sortedByDescending { it.observationDate }
 
-  @JsonClass(generateAdapter = true)
-  internal data class GetParcelResponse(
-      val colli: Map<String, Parcel>,
-  )
+        val observationsHistoryItems =
+            observations
+                .filter { (_, _, description) -> description != null }
+                .map { (observationDate, observationCode, description) ->
+                    ParcelHistoryItem(description ?: "", observationDate, location = "")
+                }
 
-  @JsonClass(generateAdapter = true)
-  internal data class Parcel(
-      val analyticsInfo: AnalyticsInfo,
-      val observations: List<Observation>,
-      val eta: Eta?,
-  ) {
+        val currentStatus =
+            observations.firstOrNull { it.status() != Status.Unknown }?.status() ?: Status.Unknown
+
+        val history = (etaHistoryItem?.let { listOf(it) } ?: emptyList()) + observationsHistoryItems
+        return Parcel(trackingId, history = history, currentStatus)
+    }
+
+    private interface API {
+        @GET("trackAndTrace/{parcel}")
+        suspend fun getParcel(
+            @Path("parcel") parcel: String,
+            @Query("language") lang: String = "en",
+        ): GetParcelResponse
+    }
+
     @JsonClass(generateAdapter = true)
-    internal data class AnalyticsInfo(val allObservations: List<Observation>)
+    internal data class GetParcelResponse(val colli: Map<String, Parcel>)
 
     @JsonClass(generateAdapter = true)
-    internal data class Eta(val type: String, val start: LocalDateTime?, val end: LocalDateTime?)
-
-    @JsonClass(generateAdapter = true)
-    internal data class Observation(
-        val observationDate: LocalDateTime,
-        val observationCode: String,
-        val description: String?
+    internal data class Parcel(
+        val analyticsInfo: AnalyticsInfo,
+        val observations: List<Observation>,
+        val eta: Eta?,
     ) {
+        @JsonClass(generateAdapter = true)
+        internal data class AnalyticsInfo(val allObservations: List<Observation>)
 
-      fun status(): Status {
-        return eventCodeToStatus(this.observationCode)
-      }
-    }
-  }
+        @JsonClass(generateAdapter = true)
+        internal data class Eta(
+            val type: String,
+            val start: LocalDateTime?,
+            val end: LocalDateTime?,
+        )
 
-  // from: https://developer.postnl.nl/docs/#/http/reference-data/t-t-status-codes/event-codes
-  private fun eventCodeToStatus(eventCode: String): Status {
-    return when (eventCode) {
-      "A01",
-      "A10",
-      "A71",
-      "F01",
-      "J93",
-      "M03",
-      "X80",
-      "X81" -> Status.Preadvice // "01, Zending voorgemeld"
-      "B01",
-      "X40" -> Status.InTransit // "02, Zending in ontvangst genomen"
-      "B04" -> Status.PickedUpByCourier // "03, Zending afgehaald"
-      "Z80" -> Status.PickedUp
-      "D02",
-      "D03",
-      "D04",
-      "D05",
-      "D06",
-      "D07",
-      "D09",
-      "D40",
-      "D41",
-      "H31",
-      "X42",
-      "X43",
-      "Y80",
-      "Y81" -> Status.Unknown // "04, Zending niet afgehaald"
-      "A08",
-      "A09",
-      "A11",
-      "A12",
-      "A13",
-      "A27",
-      "A28",
-      "A29",
-      "A30",
-      "A31",
-      "A32",
-      "A34",
-      "A35",
-      "A42",
-      "A43",
-      "A99",
-      "J01",
-      "J06",
-      "J07",
-      "J09",
-      "J10",
-      "J14",
-      "J16",
-      "J17",
-      "J22",
-      "J24",
-      "J26",
-      "J27",
-      "J28",
-      "J33",
-      "J36",
-      "J61",
-      "J90",
-      "Q12",
-      "Q13",
-      "R01",
-      "R06",
-      "X01",
-      "X02",
-      "X07",
-      "X08",
-      "X11",
-      "X14",
-      "X17",
-      "X20",
-      "X21",
-      "X22",
-      "X50",
-      "X51",
-      "X68",
-      "Y23",
-      "Y24",
-      "Y33",
-      "Y35",
-      "Y60",
-      "Y61",
-      "Y62" -> Status.InTransit // "05, Zending gesorteerd"
-      "D08",
-      "H10",
-      "K01",
-      "K02",
-      "K03",
-      "K30",
-      "K92",
-      "V01",
-      "V06",
-      "Y07" -> Status.InWarehouse // "06, Zending niet gesorteerd"
-      "H32",
-      "H35",
-      "J05",
-      "J08",
-      "J29",
-      "J39",
-      "J41",
-      "J42",
-      "J45",
-      "J47",
-      "J48",
-      "J55",
-      "J94",
-      "J95",
-      "K14",
-      "K15",
-      "K70",
-      "Q15",
-      "S05",
-      "T02",
-      "X04",
-      "X06",
-      "X19",
-      "X55",
-      "Y05" -> Status.InTransit // "07, Zending in distributieproces"
-      "H01",
-      "H02",
-      "H03",
-      "H04",
-      "H05",
-      "H07",
-      "H08",
-      "H09",
-      "H12",
-      "H20",
-      "H22",
-      "H24",
-      "H34",
-      "H36",
-      "H38",
-      "H51",
-      "H52",
-      "J92",
-      "K16",
-      "K41",
-      "K43",
-      "Y01",
-      "Y02",
-      "Y03",
-      "Y04",
-      "Y08",
-      "Y09",
-      "Y10",
-      "Y11",
-      "Y12",
-      "Y13",
-      "Y14",
-      "Y15",
-      "Y16",
-      "Y17",
-      "Y18",
-      "Y19",
-      "Y20",
-      "Y21",
-      "Y22",
-      "Y30",
-      "Y31",
-      "Y32",
-      "Y36",
-      "Y38",
-      "Y39",
-      "Y40",
-      "Y41",
-      "Y42",
-      "Y43",
-      "Y44",
-      "Y50",
-      "Y71" -> Status.DeliveryFailure // "08, Zending niet afgeleverd"
-      "J59",
-      "X30",
-      "X60",
-      "X61",
-      "X62",
-      "X63",
-      "X64",
-      "X65",
-      "X66",
-      "Y25",
-      "Y29" -> Status.CustomsHeld // "09, Zending bij douane"
-      "I01",
-      "I03",
-      "I05",
-      "I06",
-      "I07",
-      "I09",
-      "I10",
-      "I11",
-      "I12",
-      "I22",
-      "I23",
-      "J63",
-      "J91",
-      "K91",
-      "X24",
-      "Y26",
-      "Z01",
-      "Z02",
-      "Z03",
-      "Z04",
-      "Z05",
-      "Z06",
-      "Z08",
-      "Z09" -> Status.Delivered // "11, Zending afgeleverd"
-      "I08",
-      "J02",
-      "J12",
-      "J23",
-      "J52",
-      "X05" -> Status.AwaitingPickup // "12, Zending beschikbaar op afhaallocatie"
-      "A20",
-      "A21",
-      "A22",
-      "Q02",
-      "X03" -> Status.Preadvice // "13, Voorgemeld: nog niet aangenomen"
-      "M01" -> Status.Preadvice // "14, Voorgemeld: definitief niet aangenomen"
-      "G03" -> Status.PickedUpByCourier // "15, Manco collectie"
-      "G01",
-      "G02",
-      "G05" -> Status.InWarehouse // "16, Manco sortering"
-      "H23",
-      "K90" -> Status.OutForDelivery // "17, Manco distributie"
-      "F03",
-      "F04",
-      "F05",
-      "F06",
-      "F07",
-      "F08",
-      "F10" -> Status.Destroyed // "19, Zending afgekeurd"
-      "A76",
-      "X10",
-      "X67" -> Status.Customs // "20, Zending in inklaringsproces"
-      "V02",
-      "V03",
-      "V04",
-      "V11",
-      "V12",
-      "V13",
-      "V21",
-      "V22",
-      "V23",
-      "V31",
-      "V50" -> Status.InWarehouse // "21, Zending in voorraad"
-      "I02" -> Status.PickedUp // "22, Zending afgehaald van Postkantoor"
-      "C01" -> Status.Preadvice // "23, Afhaalopdracht gecollecteerd"
-      "H16",
-      "H25" -> Status.ReturningToSender // "27, Retour Onbestelbaar"
-      "Y37" -> Status.ReturningToSender // "28, Retour Foutieve aflevercode"
-      "A72",
-      "A74",
-      "A75",
-      "X15" -> Status.CustomsSuccess // "31, Zending klaar voor transport naar land van bestemming"
-      "A41",
-      "A46",
-      "A73",
-      "A94",
-      "B06",
-      "C02",
-      "H15",
-      "H17",
-      "H18",
-      "H30",
-      "J56",
-      "J80",
-      "K25",
-      "K71",
-      "P20",
-      "P21",
-      "P22",
-      "P23",
-      "P24",
-      "Q14",
-      "Q16",
-      "Q17",
-      "Q18",
-      "Q19",
-      "X16",
-      "X52",
-      "Y45",
-      "Y46",
-      "Y47",
-      "Y48",
-      "Y64",
-      "Y65",
-      "Y66" -> Status.Unknown // "99, Niet van toepassing"'
-      else -> logUnknownStatus("PostNL", "unknown event code: $eventCode")
+        @JsonClass(generateAdapter = true)
+        internal data class Observation(
+            val observationDate: LocalDateTime,
+            val observationCode: String,
+            val description: String?,
+        ) {
+
+            fun status(): Status {
+                return eventCodeToStatus(this.observationCode)
+            }
+        }
     }
-  }
+
+    // from: https://developer.postnl.nl/docs/#/http/reference-data/t-t-status-codes/event-codes
+    private fun eventCodeToStatus(eventCode: String): Status {
+        return when (eventCode) {
+            "A01",
+            "A10",
+            "A71",
+            "F01",
+            "J93",
+            "M03",
+            "X80",
+            "X81" -> Status.Preadvice // "01, Zending voorgemeld"
+            "B01",
+            "X40" -> Status.InTransit // "02, Zending in ontvangst genomen"
+            "B04" -> Status.PickedUpByCourier // "03, Zending afgehaald"
+            "Z80" -> Status.PickedUp
+            "D02",
+            "D03",
+            "D04",
+            "D05",
+            "D06",
+            "D07",
+            "D09",
+            "D40",
+            "D41",
+            "H31",
+            "X42",
+            "X43",
+            "Y80",
+            "Y81" -> Status.Unknown // "04, Zending niet afgehaald"
+            "A08",
+            "A09",
+            "A11",
+            "A12",
+            "A13",
+            "A27",
+            "A28",
+            "A29",
+            "A30",
+            "A31",
+            "A32",
+            "A34",
+            "A35",
+            "A42",
+            "A43",
+            "A99",
+            "J01",
+            "J06",
+            "J07",
+            "J09",
+            "J10",
+            "J14",
+            "J16",
+            "J17",
+            "J22",
+            "J24",
+            "J26",
+            "J27",
+            "J28",
+            "J33",
+            "J36",
+            "J61",
+            "J90",
+            "Q12",
+            "Q13",
+            "R01",
+            "R06",
+            "X01",
+            "X02",
+            "X07",
+            "X08",
+            "X11",
+            "X14",
+            "X17",
+            "X20",
+            "X21",
+            "X22",
+            "X50",
+            "X51",
+            "X68",
+            "Y23",
+            "Y24",
+            "Y33",
+            "Y35",
+            "Y60",
+            "Y61",
+            "Y62" -> Status.InTransit // "05, Zending gesorteerd"
+            "D08",
+            "H10",
+            "K01",
+            "K02",
+            "K03",
+            "K30",
+            "K92",
+            "V01",
+            "V06",
+            "Y07" -> Status.InWarehouse // "06, Zending niet gesorteerd"
+            "H32",
+            "H35",
+            "J05",
+            "J08",
+            "J29",
+            "J39",
+            "J41",
+            "J42",
+            "J45",
+            "J47",
+            "J48",
+            "J55",
+            "J94",
+            "J95",
+            "K14",
+            "K15",
+            "K70",
+            "Q15",
+            "S05",
+            "T02",
+            "X04",
+            "X06",
+            "X19",
+            "X55",
+            "Y05" -> Status.InTransit // "07, Zending in distributieproces"
+            "H01",
+            "H02",
+            "H03",
+            "H04",
+            "H05",
+            "H07",
+            "H08",
+            "H09",
+            "H12",
+            "H20",
+            "H22",
+            "H24",
+            "H34",
+            "H36",
+            "H38",
+            "H51",
+            "H52",
+            "J92",
+            "K16",
+            "K41",
+            "K43",
+            "Y01",
+            "Y02",
+            "Y03",
+            "Y04",
+            "Y08",
+            "Y09",
+            "Y10",
+            "Y11",
+            "Y12",
+            "Y13",
+            "Y14",
+            "Y15",
+            "Y16",
+            "Y17",
+            "Y18",
+            "Y19",
+            "Y20",
+            "Y21",
+            "Y22",
+            "Y30",
+            "Y31",
+            "Y32",
+            "Y36",
+            "Y38",
+            "Y39",
+            "Y40",
+            "Y41",
+            "Y42",
+            "Y43",
+            "Y44",
+            "Y50",
+            "Y71" -> Status.DeliveryFailure // "08, Zending niet afgeleverd"
+            "J59",
+            "X30",
+            "X60",
+            "X61",
+            "X62",
+            "X63",
+            "X64",
+            "X65",
+            "X66",
+            "Y25",
+            "Y29" -> Status.CustomsHeld // "09, Zending bij douane"
+            "I01",
+            "I03",
+            "I05",
+            "I06",
+            "I07",
+            "I09",
+            "I10",
+            "I11",
+            "I12",
+            "I22",
+            "I23",
+            "J63",
+            "J91",
+            "K91",
+            "X24",
+            "Y26",
+            "Z01",
+            "Z02",
+            "Z03",
+            "Z04",
+            "Z05",
+            "Z06",
+            "Z08",
+            "Z09" -> Status.Delivered // "11, Zending afgeleverd"
+            "I08",
+            "J02",
+            "J12",
+            "J23",
+            "J52",
+            "X05" -> Status.AwaitingPickup // "12, Zending beschikbaar op afhaallocatie"
+            "A20",
+            "A21",
+            "A22",
+            "Q02",
+            "X03" -> Status.Preadvice // "13, Voorgemeld: nog niet aangenomen"
+            "M01" -> Status.Preadvice // "14, Voorgemeld: definitief niet aangenomen"
+            "G03" -> Status.PickedUpByCourier // "15, Manco collectie"
+            "G01",
+            "G02",
+            "G05" -> Status.InWarehouse // "16, Manco sortering"
+            "H23",
+            "K90" -> Status.OutForDelivery // "17, Manco distributie"
+            "F03",
+            "F04",
+            "F05",
+            "F06",
+            "F07",
+            "F08",
+            "F10" -> Status.Destroyed // "19, Zending afgekeurd"
+            "A76",
+            "X10",
+            "X67" -> Status.Customs // "20, Zending in inklaringsproces"
+            "V02",
+            "V03",
+            "V04",
+            "V11",
+            "V12",
+            "V13",
+            "V21",
+            "V22",
+            "V23",
+            "V31",
+            "V50" -> Status.InWarehouse // "21, Zending in voorraad"
+            "I02" -> Status.PickedUp // "22, Zending afgehaald van Postkantoor"
+            "C01" -> Status.Preadvice // "23, Afhaalopdracht gecollecteerd"
+            "H16",
+            "H25" -> Status.ReturningToSender // "27, Retour Onbestelbaar"
+            "Y37" -> Status.ReturningToSender // "28, Retour Foutieve aflevercode"
+            "A72",
+            "A74",
+            "A75",
+            "X15" ->
+                Status.CustomsSuccess // "31, Zending klaar voor transport naar land van bestemming"
+            "A41",
+            "A46",
+            "A73",
+            "A94",
+            "B06",
+            "C02",
+            "H15",
+            "H17",
+            "H18",
+            "H30",
+            "J56",
+            "J80",
+            "K25",
+            "K71",
+            "P20",
+            "P21",
+            "P22",
+            "P23",
+            "P24",
+            "Q14",
+            "Q16",
+            "Q17",
+            "Q18",
+            "Q19",
+            "X16",
+            "X52",
+            "Y45",
+            "Y46",
+            "Y47",
+            "Y48",
+            "Y64",
+            "Y65",
+            "Y66" -> Status.Unknown // "99, Niet van toepassing"'
+            else -> logUnknownStatus("PostNL", "unknown event code: $eventCode")
+        }
+    }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
@@ -16,125 +16,124 @@ import retrofit2.http.Query
 // And additional information about locales from
 // https://developer.postnord.com/apis/details?systemName=shipment-v5-trackandtrace-shipmentinformation
 object PostNordDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_postnord
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
+  override val nameResource: Int = R.string.service_postnord
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
 
-    // Tracking URL parsing not yet supported. PostNord's widely-used shareable format
-    // is tracking.postnord.com's widget link (https://tracking.postnord.com/?id=
-    // <obfuscated>), documented in PostNord's own tracking widget implementation
-    // guide - but that id is an opaque mix of an API key and the shipment ID, not a
-    // recoverable tracking number, so it can't be parsed as-is. Per-country sites
-    // (postnord.se/.no/.dk/.com) may accept a plain shipmentId query param when
-    // tracking manually, but that's unconfirmed.
+  // Tracking URL parsing not yet supported. PostNord's widely-used shareable format
+  // is tracking.postnord.com's widget link (https://tracking.postnord.com/?id=
+  // <obfuscated>), documented in PostNord's own tracking widget implementation
+  // guide - but that id is an opaque mix of an API key and the shipment ID, not a
+  // recoverable tracking number, so it can't be parsed as-is. Per-country sites
+  // (postnord.se/.no/.dk/.com) may accept a plain shipmentId query param when
+  // tracking manually, but that's unconfirmed.
 
-    // Define supported locales and default
-    private const val DEFAULT_LOCALE = "en"
-    private val supportedLocales = setOf("en", "sv", "no", "da", "fi")
+  // Define supported locales and default
+  private const val DEFAULT_LOCALE = "en"
+  private val supportedLocales = setOf("en", "sv", "no", "da", "fi")
 
-    private fun getApiLocale(): String {
-        val locale = LocaleList.getDefault().get(0).language
-        return if (supportedLocales.contains(locale)) locale else DEFAULT_LOCALE
-    }
+  private fun getApiLocale(): String {
+    val locale = LocaleList.getDefault().get(0).language
+    return if (supportedLocales.contains(locale)) locale else DEFAULT_LOCALE
+  }
 
-    private val statusMapping =
-        mapOf(
-            "CREATED" to Status.Preadvice,
-            "EN_ROUTE" to Status.InTransit,
-            "DELAYED" to Status.InTransit,
-            "EXPECTED_DELAY" to Status.InTransit,
-            "AVAILABLE_FOR_DELIVERY" to Status.InWarehouse,
-            "AVAILABLE_FOR_DELIVERY_PAR_LOC" to Status.InWarehouse,
-            "DELIVERED" to Status.Delivered,
-            "DELIVERY_IMPOSSIBLE" to Status.DeliveryFailure,
-            "DELIVERY_REFUSED" to Status.DeliveryFailure,
-            "STOPPED" to Status.DeliveryFailure,
-            "RETURNED" to Status.DeliveryFailure,
-            "OTHER" to Status.Unknown,
-            "INFORMED" to Status.Unknown,
-        )
+  private val statusMapping =
+      mapOf(
+          "CREATED" to Status.Preadvice,
+          "EN_ROUTE" to Status.InTransit,
+          "DELAYED" to Status.InTransit,
+          "EXPECTED_DELAY" to Status.InTransit,
+          "AVAILABLE_FOR_DELIVERY" to Status.InWarehouse,
+          "AVAILABLE_FOR_DELIVERY_PAR_LOC" to Status.InWarehouse,
+          "DELIVERED" to Status.Delivered,
+          "DELIVERY_IMPOSSIBLE" to Status.DeliveryFailure,
+          "DELIVERY_REFUSED" to Status.DeliveryFailure,
+          "STOPPED" to Status.DeliveryFailure,
+          "RETURNED" to Status.DeliveryFailure,
+          "OTHER" to Status.Unknown,
+          "INFORMED" to Status.Unknown,
+      )
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val resp =
-            try {
-                service.getShipments(trackingId, getApiLocale())
-            } catch (e: HttpException) {
-                when (e.code()) {
-                    404 -> throw ParcelNonExistentException()
-                    else -> throw IOException("Failed to fetch parcel information: ${e.message()}")
-                }
-            }
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val resp =
+        try {
+          service.getShipments(trackingId, getApiLocale())
+        } catch (e: HttpException) {
+          when (e.code()) {
+            404 -> throw ParcelNonExistentException()
+            else -> throw IOException("Failed to fetch parcel information: ${e.message()}")
+          }
+        }
 
-        val item = resp.items.firstOrNull() ?: throw ParcelNonExistentException()
+    val item = resp.items.firstOrNull() ?: throw ParcelNonExistentException()
 
-        val status =
-            statusMapping[item.status.code] ?: logUnknownStatus("PostNord", item.status.code)
+    val status = statusMapping[item.status.code] ?: logUnknownStatus("PostNord", item.status.code)
 
-        val history =
-            item.events.map { event ->
-                val location = event.location
-                val locationName = location.name
-                val locationCountryCode = location.countryCode
+    val history =
+        item.events.map { event ->
+          val location = event.location
+          val locationName = location.name
+          val locationCountryCode = location.countryCode
 
-                ParcelHistoryItem(
-                    event.eventDescription,
-                    ZonedDateTime.parse(event.eventTime)
-                        .withZoneSameInstant(ZoneId.systemDefault())
-                        .toLocalDateTime(),
-                    listOfNotNull(locationName, locationCountryCode).joinToString(", "),
-                )
-            }
+          ParcelHistoryItem(
+              event.eventDescription,
+              ZonedDateTime.parse(event.eventTime)
+                  .withZoneSameInstant(ZoneId.systemDefault())
+                  .toLocalDateTime(),
+              listOfNotNull(locationName, locationCountryCode).joinToString(", "),
+          )
+        }
 
-        return Parcel(resp.shipmentId, history, status)
-    }
+    return Parcel(resp.shipmentId, history, status)
+  }
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://api2.postnord.com/rest/shipment/v1/trackingweb/")
-            .client(api_client)
-            .addConverterFactory(api_factory)
-            .build()
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://api2.postnord.com/rest/shipment/v1/trackingweb/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
 
-    private val service = retrofit.create(API::class.java)
+  private val service = retrofit.create(API::class.java)
 
-    private interface API {
-        @GET("shipmentInformation")
-        @Headers("x-bap-key: web-tracking-sc")
-        suspend fun getShipments(
-            @Query("shipmentId") id: String,
-            @Query("locale") locale: String,
-        ): ShipmentResponse
-    }
+  private interface API {
+    @GET("shipmentInformation")
+    @Headers("x-bap-key: web-tracking-sc")
+    suspend fun getShipments(
+        @Query("shipmentId") id: String,
+        @Query("locale") locale: String,
+    ): ShipmentResponse
+  }
 
-    @JsonClass(generateAdapter = true)
-    internal data class ShipmentResponse(val shipmentId: String, val items: List<Item>)
+  @JsonClass(generateAdapter = true)
+  internal data class ShipmentResponse(val shipmentId: String, val items: List<Item>)
 
-    @JsonClass(generateAdapter = true)
-    internal data class Item(
-        val itemId: String,
-        val deliveryInformation: DeliveryInformation,
-        val events: List<Event>,
-        val status: ItemStatus,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Item(
+      val itemId: String,
+      val deliveryInformation: DeliveryInformation,
+      val events: List<Event>,
+      val status: ItemStatus,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class DeliveryInformation(val deliveryTo: String, val deliveryToInfo: String)
+  @JsonClass(generateAdapter = true)
+  internal data class DeliveryInformation(val deliveryTo: String, val deliveryToInfo: String)
 
-    @JsonClass(generateAdapter = true)
-    internal data class Event(
-        val eventDescription: String,
-        val eventTime: String, // ISO-8601 representation of the datetime
-        val status: String,
-        val location: Location,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Event(
+      val eventDescription: String,
+      val eventTime: String, // ISO-8601 representation of the datetime
+      val status: String,
+      val location: Location,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class Location(
-        val countryCode: String? = null,
-        val locationType: String?,
-        val name: String?,
-    )
+  @JsonClass(generateAdapter = true)
+  internal data class Location(
+      val countryCode: String? = null,
+      val locationType: String?,
+      val name: String?,
+  )
 
-    @JsonClass(generateAdapter = true)
-    internal data class ItemStatus(val code: String, val header: String, val description: String)
+  @JsonClass(generateAdapter = true)
+  internal data class ItemStatus(val code: String, val header: String, val description: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
@@ -16,117 +16,125 @@ import retrofit2.http.Query
 // And additional information about locales from
 // https://developer.postnord.com/apis/details?systemName=shipment-v5-trackandtrace-shipmentinformation
 object PostNordDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_postnord
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
+    override val nameResource: Int = R.string.service_postnord
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
 
-  // Define supported locales and default
-  private const val DEFAULT_LOCALE = "en"
-  private val supportedLocales = setOf("en", "sv", "no", "da", "fi")
+    // Tracking URL parsing not yet supported. PostNord's widely-used shareable format
+    // is tracking.postnord.com's widget link (https://tracking.postnord.com/?id=
+    // <obfuscated>), documented in PostNord's own tracking widget implementation
+    // guide - but that id is an opaque mix of an API key and the shipment ID, not a
+    // recoverable tracking number, so it can't be parsed as-is. Per-country sites
+    // (postnord.se/.no/.dk/.com) may accept a plain shipmentId query param when
+    // tracking manually, but that's unconfirmed.
 
-  private fun getApiLocale(): String {
-    val locale = LocaleList.getDefault().get(0).language
-    return if (supportedLocales.contains(locale)) locale else DEFAULT_LOCALE
-  }
+    // Define supported locales and default
+    private const val DEFAULT_LOCALE = "en"
+    private val supportedLocales = setOf("en", "sv", "no", "da", "fi")
 
-  private val statusMapping =
-      mapOf(
-          "CREATED" to Status.Preadvice,
-          "EN_ROUTE" to Status.InTransit,
-          "DELAYED" to Status.InTransit,
-          "EXPECTED_DELAY" to Status.InTransit,
-          "AVAILABLE_FOR_DELIVERY" to Status.InWarehouse,
-          "AVAILABLE_FOR_DELIVERY_PAR_LOC" to Status.InWarehouse,
-          "DELIVERED" to Status.Delivered,
-          "DELIVERY_IMPOSSIBLE" to Status.DeliveryFailure,
-          "DELIVERY_REFUSED" to Status.DeliveryFailure,
-          "STOPPED" to Status.DeliveryFailure,
-          "RETURNED" to Status.DeliveryFailure,
-          "OTHER" to Status.Unknown,
-          "INFORMED" to Status.Unknown)
+    private fun getApiLocale(): String {
+        val locale = LocaleList.getDefault().get(0).language
+        return if (supportedLocales.contains(locale)) locale else DEFAULT_LOCALE
+    }
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val resp =
-        try {
-          service.getShipments(trackingId, getApiLocale())
-        } catch (e: HttpException) {
-          when (e.code()) {
-            404 -> throw ParcelNonExistentException()
-            else -> throw IOException("Failed to fetch parcel information: ${e.message()}")
-          }
-        }
+    private val statusMapping =
+        mapOf(
+            "CREATED" to Status.Preadvice,
+            "EN_ROUTE" to Status.InTransit,
+            "DELAYED" to Status.InTransit,
+            "EXPECTED_DELAY" to Status.InTransit,
+            "AVAILABLE_FOR_DELIVERY" to Status.InWarehouse,
+            "AVAILABLE_FOR_DELIVERY_PAR_LOC" to Status.InWarehouse,
+            "DELIVERED" to Status.Delivered,
+            "DELIVERY_IMPOSSIBLE" to Status.DeliveryFailure,
+            "DELIVERY_REFUSED" to Status.DeliveryFailure,
+            "STOPPED" to Status.DeliveryFailure,
+            "RETURNED" to Status.DeliveryFailure,
+            "OTHER" to Status.Unknown,
+            "INFORMED" to Status.Unknown,
+        )
 
-    val item = resp.items.firstOrNull() ?: throw ParcelNonExistentException()
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val resp =
+            try {
+                service.getShipments(trackingId, getApiLocale())
+            } catch (e: HttpException) {
+                when (e.code()) {
+                    404 -> throw ParcelNonExistentException()
+                    else -> throw IOException("Failed to fetch parcel information: ${e.message()}")
+                }
+            }
 
-    val status = statusMapping[item.status.code] ?: logUnknownStatus("PostNord", item.status.code)
+        val item = resp.items.firstOrNull() ?: throw ParcelNonExistentException()
 
-    val history =
-        item.events.map { event ->
-          val location = event.location
-          val locationName = location.name
-          val locationCountryCode = location.countryCode
+        val status =
+            statusMapping[item.status.code] ?: logUnknownStatus("PostNord", item.status.code)
 
-          ParcelHistoryItem(
-              event.eventDescription,
-              ZonedDateTime.parse(event.eventTime)
-                  .withZoneSameInstant(ZoneId.systemDefault())
-                  .toLocalDateTime(),
-              listOfNotNull(locationName, locationCountryCode).joinToString(", "))
-        }
+        val history =
+            item.events.map { event ->
+                val location = event.location
+                val locationName = location.name
+                val locationCountryCode = location.countryCode
 
-    return Parcel(resp.shipmentId, history, status)
-  }
+                ParcelHistoryItem(
+                    event.eventDescription,
+                    ZonedDateTime.parse(event.eventTime)
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime(),
+                    listOfNotNull(locationName, locationCountryCode).joinToString(", "),
+                )
+            }
 
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://api2.postnord.com/rest/shipment/v1/trackingweb/")
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
+        return Parcel(resp.shipmentId, history, status)
+    }
 
-  private val service = retrofit.create(API::class.java)
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://api2.postnord.com/rest/shipment/v1/trackingweb/")
+            .client(api_client)
+            .addConverterFactory(api_factory)
+            .build()
 
-  private interface API {
-    @GET("shipmentInformation")
-    @Headers("x-bap-key: web-tracking-sc")
-    suspend fun getShipments(
-        @Query("shipmentId") id: String,
-        @Query("locale") locale: String
-    ): ShipmentResponse
-  }
+    private val service = retrofit.create(API::class.java)
 
-  @JsonClass(generateAdapter = true)
-  internal data class ShipmentResponse(val shipmentId: String, val items: List<Item>)
+    private interface API {
+        @GET("shipmentInformation")
+        @Headers("x-bap-key: web-tracking-sc")
+        suspend fun getShipments(
+            @Query("shipmentId") id: String,
+            @Query("locale") locale: String,
+        ): ShipmentResponse
+    }
 
-  @JsonClass(generateAdapter = true)
-  internal data class Item(
-      val itemId: String,
-      val deliveryInformation: DeliveryInformation,
-      val events: List<Event>,
-      val status: ItemStatus
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class ShipmentResponse(val shipmentId: String, val items: List<Item>)
 
-  @JsonClass(generateAdapter = true)
-  internal data class DeliveryInformation(
-      val deliveryTo: String,
-      val deliveryToInfo: String,
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Item(
+        val itemId: String,
+        val deliveryInformation: DeliveryInformation,
+        val events: List<Event>,
+        val status: ItemStatus,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class Event(
-      val eventDescription: String,
-      val eventTime: String, // ISO-8601 representation of the datetime
-      val status: String,
-      val location: Location
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class DeliveryInformation(val deliveryTo: String, val deliveryToInfo: String)
 
-  @JsonClass(generateAdapter = true)
-  internal data class Location(
-      val countryCode: String? = null,
-      val locationType: String?,
-      val name: String?
-  )
+    @JsonClass(generateAdapter = true)
+    internal data class Event(
+        val eventDescription: String,
+        val eventTime: String, // ISO-8601 representation of the datetime
+        val status: String,
+        val location: Location,
+    )
 
-  @JsonClass(generateAdapter = true)
-  internal data class ItemStatus(val code: String, val header: String, val description: String)
+    @JsonClass(generateAdapter = true)
+    internal data class Location(
+        val countryCode: String? = null,
+        val locationType: String?,
+        val name: String?,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class ItemStatus(val code: String, val header: String, val description: String)
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/SamedayDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/SamedayDeliveryService.kt
@@ -10,11 +10,35 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
 
-object SamedayRomaniaDeliveryService : SamedayDeliveryService("ro", R.string.service_sameday_ro)
+object SamedayRomaniaDeliveryService : SamedayDeliveryService("ro", R.string.service_sameday_ro) {
+  // Confirmed: verified against real link (fragment and status-colet query variants)
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://(?:www\.)?sameday\.ro/\S*[?#]awb=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)),
+      )
+}
 
-object SamedayHungaryDeliveryService : SamedayDeliveryService("hu", R.string.service_sameday_hu)
+object SamedayHungaryDeliveryService : SamedayDeliveryService("hu", R.string.service_sameday_hu) {
+  // Confirmed: verified against real link
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://(?:www\.)?sameday\.hu/\S*[?#]awb=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)),
+      )
+}
 
-object SamedayBulgariaDeliveryService : SamedayDeliveryService("bg", R.string.service_sameday_bg)
+object SamedayBulgariaDeliveryService : SamedayDeliveryService("bg", R.string.service_sameday_bg) {
+  // Confirmed: verified against real link (fragment and status-na-pratkata query variants)
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://(?:www\.)?sameday\.bg/\S*[?#]awb=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)),
+      )
+}
 
 open class SamedayDeliveryService(region: String, override val nameResource: Int) :
     DeliveryService {

--- a/app/src/main/java/dev/itsvic/parceltracker/api/TrackingUrlParser.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/TrackingUrlParser.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.api
+
+private val urlSubstringRegex = """https?://\S+""".toRegex()
+
+data class TrackingUrlMatch(
+    val service: Service,
+    val trackingId: String,
+    val postalCode: String? = null,
+)
+
+// Extracts the first http(s) URL substring out of raw shared text (e.g. an
+// ACTION_SEND EXTRA_TEXT payload that may contain a title/sentence around
+// the link), trimming common trailing punctuation picked up by the regex.
+fun extractFirstUrl(rawText: String): String? =
+    urlSubstringRegex.find(rawText)?.value?.trimEnd('.', ',', ')', ']', '>', '"', '\'')
+
+// Matches a full URL string against every in-scope provider's trackingUrlPatterns.
+fun parseTrackingUrl(url: String): TrackingUrlMatch? {
+    for (service in serviceOptions) {
+        val backend = getDeliveryService(service) ?: continue
+        for (pattern in backend.trackingUrlPatterns) {
+            val trackingId =
+                pattern.urlRegex.find(url)?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+                    ?: continue
+            val postalCode =
+                pattern.postalCodeRegex?.find(url)?.groupValues?.getOrNull(1)?.takeIf {
+                    it.isNotBlank()
+                }
+            return TrackingUrlMatch(service, trackingId, postalCode)
+        }
+    }
+    return null
+}
+
+// Convenience wrapper for ACTION_SEND: extracts a URL from raw text first.
+fun parseSharedText(rawText: String): TrackingUrlMatch? =
+    extractFirstUrl(rawText)?.let { parseTrackingUrl(it) }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/TrackingUrlParser.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/TrackingUrlParser.kt
@@ -17,20 +17,18 @@ fun extractFirstUrl(rawText: String): String? =
 
 // Matches a full URL string against every in-scope provider's trackingUrlPatterns.
 fun parseTrackingUrl(url: String): TrackingUrlMatch? {
-    for (service in serviceOptions) {
-        val backend = getDeliveryService(service) ?: continue
-        for (pattern in backend.trackingUrlPatterns) {
-            val trackingId =
-                pattern.urlRegex.find(url)?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
-                    ?: continue
-            val postalCode =
-                pattern.postalCodeRegex?.find(url)?.groupValues?.getOrNull(1)?.takeIf {
-                    it.isNotBlank()
-                }
-            return TrackingUrlMatch(service, trackingId, postalCode)
-        }
+  for (service in serviceOptions) {
+    val backend = getDeliveryService(service) ?: continue
+    for (pattern in backend.trackingUrlPatterns) {
+      val trackingId =
+          pattern.urlRegex.find(url)?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+              ?: continue
+      val postalCode =
+          pattern.postalCodeRegex?.find(url)?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+      return TrackingUrlMatch(service, trackingId, postalCode)
     }
-    return null
+  }
+  return null
 }
 
 // Convenience wrapper for ACTION_SEND: extracts a URL from raw text first.

--- a/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
@@ -24,232 +24,230 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 object UPSDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_ups
-    override val acceptsPostCode: Boolean = false
-    override val requiresPostCode: Boolean = false
+  override val nameResource: Int = R.string.service_ups
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
 
-    // Confirmed: documented as the current UPS tracking link format (used when
-    // pasting a tracking number into ups.com, and in UPS-sent tracking emails).
-    override val trackingUrlPatterns: List<TrackingUrlPattern> =
-        listOf(
-            TrackingUrlPattern(
-                """https?://(?:www\.)?ups\.com/track\S*[?&]tracknum=([A-Za-z0-9]+)"""
-                    .toRegex(RegexOption.IGNORE_CASE)
-            )
-        )
+  // Confirmed: documented as the current UPS tracking link format (used when
+  // pasting a tracking number into ups.com, and in UPS-sent tracking emails).
+  override val trackingUrlPatterns: List<TrackingUrlPattern> =
+      listOf(
+          TrackingUrlPattern(
+              """https?://(?:www\.)?ups\.com/track\S*[?&]tracknum=([A-Za-z0-9]+)"""
+                  .toRegex(RegexOption.IGNORE_CASE)))
 
-    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-        val tokens = getCsrfTokens(trackingId)
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val tokens = getCsrfTokens(trackingId)
 
-        val language = LocaleList.getDefault().get(0)
-        val country = language.country.ifEmpty { defaultRegionsForLanguageCode[language.language] }
-        val locale = "${language.language}_$country"
+    val language = LocaleList.getDefault().get(0)
+    val country = language.country.ifEmpty { defaultRegionsForLanguageCode[language.language] }
+    val locale = "${language.language}_$country"
 
-        val resp =
-            try {
-                service.getStatus(
-                    locale,
-                    "X-CSRF-TOKEN=${tokens.first}",
-                    tokens.second,
-                    GetStatusRequest(locale, listOf(trackingId.lowercase())),
-                )
-            } catch (_: HttpException) {
-                throw ParcelNonExistentException()
-            }
-
-        if (resp.trackDetails == null || resp.trackDetails.isEmpty()) {
-            throw ParcelNonExistentException()
+    val resp =
+        try {
+          service.getStatus(
+              locale,
+              "X-CSRF-TOKEN=${tokens.first}",
+              tokens.second,
+              GetStatusRequest(locale, listOf(trackingId.lowercase())),
+          )
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
         }
 
-        val details = resp.trackDetails.first()
+    if (resp.trackDetails == null || resp.trackDetails.isEmpty()) {
+      throw ParcelNonExistentException()
+    }
 
-        if (details.errorCode != null) {
-            throw ParcelNonExistentException()
-        }
+    val details = resp.trackDetails.first()
 
-        val history =
-            details.shipmentProgressActivities!!.map {
-                val gmtDate =
-                    LocalDateTime.parse(
-                        "${it.gmtDate.subSequence(0, 4)}-${
+    if (details.errorCode != null) {
+      throw ParcelNonExistentException()
+    }
+
+    val history =
+        details.shipmentProgressActivities!!.map {
+          val gmtDate =
+              LocalDateTime.parse(
+                  "${it.gmtDate.subSequence(0, 4)}-${
                     it.gmtDate.subSequence(
                         4,
                         6,
                     )
                 }-${it.gmtDate.subSequence(6, 8)}T${it.gmtTime}",
-                        DateTimeFormatter.ISO_DATE_TIME,
-                    )
-                val adjustedDate =
-                    gmtDate
-                        .atOffset(ZoneOffset.UTC)
-                        .withOffsetSameInstant(ZoneId.systemDefault().rules.getOffset(gmtDate))
-                        .toLocalDateTime()
+                  DateTimeFormatter.ISO_DATE_TIME,
+              )
+          val adjustedDate =
+              gmtDate
+                  .atOffset(ZoneOffset.UTC)
+                  .withOffsetSameInstant(ZoneId.systemDefault().rules.getOffset(gmtDate))
+                  .toLocalDateTime()
 
-                ParcelHistoryItem(
-                    Html.fromHtml(it.activityScan, Html.FROM_HTML_MODE_LEGACY).toString(),
-                    adjustedDate,
-                    it.location,
-                )
-            }
-
-        val status =
-            when (details.progressBarType) {
-                "ManifestUpload" -> Status.Preadvice
-                "FirstUPSPossession" -> Status.InTransit
-                "InTransit" -> Status.InTransit
-                "OutForDelivery" -> Status.OutForDelivery
-                "Delivered" -> Status.Delivered
-                "Exception" -> Status.DeliveryFailure
-                else -> logUnknownStatus("UPS", details.progressBarType!!)
-            }
-
-        val metadata = mutableMapOf<Int, String>()
-        if (details.additionalInformation?.weightUnit != null) {
-            metadata[R.string.property_weight] =
-                "${details.additionalInformation.weight} ${details.additionalInformation.weightUnit}"
+          ParcelHistoryItem(
+              Html.fromHtml(it.activityScan, Html.FROM_HTML_MODE_LEGACY).toString(),
+              adjustedDate,
+              it.location,
+          )
         }
 
-        // ETA
-        if (details.scheduledDeliveryDateDetail != null && details.packageStatusTime != null) {
-            val month =
-                when (details.scheduledDeliveryDateDetail.monthCMSKey) {
-                    "cms.stapp.jan" -> 1
-                    "cms.stapp.feb" -> 2
-                    "cms.stapp.mar" -> 3
-                    "cms.stapp.apr" -> 4
-                    "cms.stapp.may" -> 5
-                    "cms.stapp.jun" -> 6
-                    "cms.stapp.jul" -> 7
-                    "cms.stapp.aug" -> 8
-                    "cms.stapp.sep" -> 9
-                    "cms.stapp.oct" -> 10
-                    "cms.stapp.nov" -> 11
-                    "cms.stapp.dec" -> 12
-                    else -> 0
-                }
-            val day = details.scheduledDeliveryDateDetail.dayNum.toInt()
-            val date = LocalDate.now().withMonth(month).withDayOfMonth(day)
-            val eta =
-                (date?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)) +
-                    "\n"
-                    // cleanup A.M., P.M. -> AM, PM
-                    +
-                    details.packageStatusTime.replace(".M.", "M"))
-            metadata[R.string.property_eta] = eta
+    val status =
+        when (details.progressBarType) {
+          "ManifestUpload" -> Status.Preadvice
+          "FirstUPSPossession" -> Status.InTransit
+          "InTransit" -> Status.InTransit
+          "OutForDelivery" -> Status.OutForDelivery
+          "Delivered" -> Status.Delivered
+          "Exception" -> Status.DeliveryFailure
+          else -> logUnknownStatus("UPS", details.progressBarType!!)
         }
 
-        return Parcel(trackingId, history, status, metadata)
+    val metadata = mutableMapOf<Int, String>()
+    if (details.additionalInformation?.weightUnit != null) {
+      metadata[R.string.property_weight] =
+          "${details.additionalInformation.weight} ${details.additionalInformation.weightUnit}"
     }
 
-    private val retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://webapis.ups.com/track/api/")
-            .client(api_client)
-            .addConverterFactory(api_factory)
+    // ETA
+    if (details.scheduledDeliveryDateDetail != null && details.packageStatusTime != null) {
+      val month =
+          when (details.scheduledDeliveryDateDetail.monthCMSKey) {
+            "cms.stapp.jan" -> 1
+            "cms.stapp.feb" -> 2
+            "cms.stapp.mar" -> 3
+            "cms.stapp.apr" -> 4
+            "cms.stapp.may" -> 5
+            "cms.stapp.jun" -> 6
+            "cms.stapp.jul" -> 7
+            "cms.stapp.aug" -> 8
+            "cms.stapp.sep" -> 9
+            "cms.stapp.oct" -> 10
+            "cms.stapp.nov" -> 11
+            "cms.stapp.dec" -> 12
+            else -> 0
+          }
+      val day = details.scheduledDeliveryDateDetail.dayNum.toInt()
+      val date = LocalDate.now().withMonth(month).withDayOfMonth(day)
+      val eta =
+          (date?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)) +
+              "\n"
+              // cleanup A.M., P.M. -> AM, PM
+              +
+              details.packageStatusTime.replace(".M.", "M"))
+      metadata[R.string.property_eta] = eta
+    }
+
+    return Parcel(trackingId, history, status, metadata)
+  }
+
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://webapis.ups.com/track/api/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
+
+  private val service = retrofit.create(API::class.java)
+
+  private interface API {
+    @Headers(
+        "accept: application/json, text/plain, */*",
+        "accept-language: en-US,en;q=0.9",
+        "origin: https://www.ups.com",
+        "sec-ch-ua: \"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
+        "sec-ch-ua-mobile: ?0",
+        "sec-ch-ua-platform: \"Linux\"",
+        "sec-fetch-dest: empty",
+        "sec-fetch-mode: cors",
+        "sec-fetch-site: same-site",
+        "user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+    )
+    @POST("Track/GetStatus")
+    suspend fun getStatus(
+        @Query("loc") locale: String = "en_US",
+        @Header("cookie") csrfTokenCookie: String,
+        @Header("x-xsrf-token") xsrfToken: String,
+        @Body data: GetStatusRequest,
+    ): GetStatusResponse
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class GetStatusRequest(
+      val Locale: String,
+      val TrackingNumber: List<String>,
+      val isBarcodeScanned: Boolean = false,
+      val Requester: String = "st",
+      val returnToValue: String = "",
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class GetStatusResponse(val trackDetails: List<TrackDetails>?)
+
+  @JsonClass(generateAdapter = true)
+  internal data class TrackDetails(
+      val errorCode: String?,
+      val progressBarType: String?,
+      val additionalInformation: PkgMoreInfo?,
+      val shipmentProgressActivities: List<ActivityEntry>?,
+      val scheduledDeliveryDateDetail: DeliveryDateDetail?,
+      val packageStatusTime: String?,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class PkgMoreInfo(val weight: String, val weightUnit: String?)
+
+  @JsonClass(generateAdapter = true)
+  internal data class ActivityEntry(
+      val location: String,
+      val activityScan: String,
+      val gmtDate: String,
+      val gmtTime: String,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class DeliveryDateDetail(val monthCMSKey: String, val dayNum: String)
+
+  // Grabs the necessary tokens by making a request to the UPS website
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private suspend fun getCsrfTokens(trackingId: String): Pair<String, String> {
+    val request =
+        Request.Builder()
+            .addHeader("accept", "*/*")
+            .addHeader("accept-language", "en-US,en;q=0.9")
+            .addHeader(
+                "sec-ch-ua",
+                "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
+            )
+            .addHeader("sec-ch-ua-mobile", "?0")
+            .addHeader("sec-ch-ua-platform", "\"Linux\"")
+            .addHeader("sec-fetch-dest", "empty")
+            .addHeader("sec-fetch-mode", "cors")
+            .addHeader("sec-fetch-site", "same-site")
+            .addHeader(
+                "user-agent",
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+            )
+            .url("https://www.ups.com/track?tracknum=${trackingId.lowercase()}")
             .build()
 
-    private val service = retrofit.create(API::class.java)
-
-    private interface API {
-        @Headers(
-            "accept: application/json, text/plain, */*",
-            "accept-language: en-US,en;q=0.9",
-            "origin: https://www.ups.com",
-            "sec-ch-ua: \"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
-            "sec-ch-ua-mobile: ?0",
-            "sec-ch-ua-platform: \"Linux\"",
-            "sec-fetch-dest: empty",
-            "sec-fetch-mode: cors",
-            "sec-fetch-site: same-site",
-            "user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
-        )
-        @POST("Track/GetStatus")
-        suspend fun getStatus(
-            @Query("loc") locale: String = "en_US",
-            @Header("cookie") csrfTokenCookie: String,
-            @Header("x-xsrf-token") xsrfToken: String,
-            @Body data: GetStatusRequest,
-        ): GetStatusResponse
-    }
-
-    @JsonClass(generateAdapter = true)
-    internal data class GetStatusRequest(
-        val Locale: String,
-        val TrackingNumber: List<String>,
-        val isBarcodeScanned: Boolean = false,
-        val Requester: String = "st",
-        val returnToValue: String = "",
-    )
-
-    @JsonClass(generateAdapter = true)
-    internal data class GetStatusResponse(val trackDetails: List<TrackDetails>?)
-
-    @JsonClass(generateAdapter = true)
-    internal data class TrackDetails(
-        val errorCode: String?,
-        val progressBarType: String?,
-        val additionalInformation: PkgMoreInfo?,
-        val shipmentProgressActivities: List<ActivityEntry>?,
-        val scheduledDeliveryDateDetail: DeliveryDateDetail?,
-        val packageStatusTime: String?,
-    )
-
-    @JsonClass(generateAdapter = true)
-    internal data class PkgMoreInfo(val weight: String, val weightUnit: String?)
-
-    @JsonClass(generateAdapter = true)
-    internal data class ActivityEntry(
-        val location: String,
-        val activityScan: String,
-        val gmtDate: String,
-        val gmtTime: String,
-    )
-
-    @JsonClass(generateAdapter = true)
-    internal data class DeliveryDateDetail(val monthCMSKey: String, val dayNum: String)
-
-    // Grabs the necessary tokens by making a request to the UPS website
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private suspend fun getCsrfTokens(trackingId: String): Pair<String, String> {
-        val request =
-            Request.Builder()
-                .addHeader("accept", "*/*")
-                .addHeader("accept-language", "en-US,en;q=0.9")
-                .addHeader(
-                    "sec-ch-ua",
-                    "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
-                )
-                .addHeader("sec-ch-ua-mobile", "?0")
-                .addHeader("sec-ch-ua-platform", "\"Linux\"")
-                .addHeader("sec-fetch-dest", "empty")
-                .addHeader("sec-fetch-mode", "cors")
-                .addHeader("sec-fetch-site", "same-site")
-                .addHeader(
-                    "user-agent",
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
-                )
-                .url("https://www.ups.com/track?tracknum=${trackingId.lowercase()}")
-                .build()
-
-        api_client.newCall(request).executeAsync().use { response ->
-            Log.d("UPS", "Got response")
-            var csrfToken = ""
-            var xsrfToken = ""
-            for (pair in response.headers) {
-                if (pair.first.lowercase() == "set-cookie") {
-                    if (pair.second.startsWith("X-CSRF-TOKEN=")) {
-                        csrfToken = pair.second.split('=')[1].split(';')[0]
-                        Log.d("UPS", "Got CSRF token: $csrfToken")
-                    }
-                    if (pair.second.startsWith("X-XSRF-TOKEN-ST=")) {
-                        xsrfToken = pair.second.split('=')[1].split(';')[0]
-                        Log.d("UPS", "Got XSRF token: $xsrfToken")
-                    }
-                }
-            }
-            return Pair(csrfToken, xsrfToken)
+    api_client.newCall(request).executeAsync().use { response ->
+      Log.d("UPS", "Got response")
+      var csrfToken = ""
+      var xsrfToken = ""
+      for (pair in response.headers) {
+        if (pair.first.lowercase() == "set-cookie") {
+          if (pair.second.startsWith("X-CSRF-TOKEN=")) {
+            csrfToken = pair.second.split('=')[1].split(';')[0]
+            Log.d("UPS", "Got CSRF token: $csrfToken")
+          }
+          if (pair.second.startsWith("X-XSRF-TOKEN-ST=")) {
+            xsrfToken = pair.second.split('=')[1].split(';')[0]
+            Log.d("UPS", "Got XSRF token: $xsrfToken")
+          }
         }
-
-        return Pair("", "")
+      }
+      return Pair(csrfToken, xsrfToken)
     }
+
+    return Pair("", "")
+  }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
@@ -24,225 +24,232 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 object UPSDeliveryService : DeliveryService {
-  override val nameResource: Int = R.string.service_ups
-  override val acceptsPostCode: Boolean = false
-  override val requiresPostCode: Boolean = false
+    override val nameResource: Int = R.string.service_ups
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
-    val tokens = getCsrfTokens(trackingId)
+    // Confirmed: documented as the current UPS tracking link format (used when
+    // pasting a tracking number into ups.com, and in UPS-sent tracking emails).
+    override val trackingUrlPatterns: List<TrackingUrlPattern> =
+        listOf(
+            TrackingUrlPattern(
+                """https?://(?:www\.)?ups\.com/track\S*[?&]tracknum=([A-Za-z0-9]+)"""
+                    .toRegex(RegexOption.IGNORE_CASE)
+            )
+        )
 
-    val language = LocaleList.getDefault().get(0)
-    val country = language.country.ifEmpty { defaultRegionsForLanguageCode[language.language] }
-    val locale = "${language.language}_$country"
+    override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+        val tokens = getCsrfTokens(trackingId)
 
-    val resp =
-        try {
-          service.getStatus(
-              locale,
-              "X-CSRF-TOKEN=${tokens.first}",
-              tokens.second,
-              GetStatusRequest(locale, listOf(trackingId.lowercase())))
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
+        val language = LocaleList.getDefault().get(0)
+        val country = language.country.ifEmpty { defaultRegionsForLanguageCode[language.language] }
+        val locale = "${language.language}_$country"
+
+        val resp =
+            try {
+                service.getStatus(
+                    locale,
+                    "X-CSRF-TOKEN=${tokens.first}",
+                    tokens.second,
+                    GetStatusRequest(locale, listOf(trackingId.lowercase())),
+                )
+            } catch (_: HttpException) {
+                throw ParcelNonExistentException()
+            }
+
+        if (resp.trackDetails == null || resp.trackDetails.isEmpty()) {
+            throw ParcelNonExistentException()
         }
 
-    if (resp.trackDetails == null || resp.trackDetails.isEmpty()) {
-      throw ParcelNonExistentException()
-    }
+        val details = resp.trackDetails.first()
 
-    val details = resp.trackDetails.first()
+        if (details.errorCode != null) {
+            throw ParcelNonExistentException()
+        }
 
-    if (details.errorCode != null) {
-      throw ParcelNonExistentException()
-    }
-
-    val history =
-        details.shipmentProgressActivities!!.map {
-          val gmtDate =
-              LocalDateTime.parse(
-                  "${it.gmtDate.subSequence(0, 4)}-${
+        val history =
+            details.shipmentProgressActivities!!.map {
+                val gmtDate =
+                    LocalDateTime.parse(
+                        "${it.gmtDate.subSequence(0, 4)}-${
                     it.gmtDate.subSequence(
                         4,
-                        6
+                        6,
                     )
                 }-${it.gmtDate.subSequence(6, 8)}T${it.gmtTime}",
-                  DateTimeFormatter.ISO_DATE_TIME)
-          val adjustedDate =
-              gmtDate
-                  .atOffset(ZoneOffset.UTC)
-                  .withOffsetSameInstant(ZoneId.systemDefault().rules.getOffset(gmtDate))
-                  .toLocalDateTime()
+                        DateTimeFormatter.ISO_DATE_TIME,
+                    )
+                val adjustedDate =
+                    gmtDate
+                        .atOffset(ZoneOffset.UTC)
+                        .withOffsetSameInstant(ZoneId.systemDefault().rules.getOffset(gmtDate))
+                        .toLocalDateTime()
 
-          ParcelHistoryItem(
-              Html.fromHtml(it.activityScan, Html.FROM_HTML_MODE_LEGACY).toString(),
-              adjustedDate,
-              it.location)
+                ParcelHistoryItem(
+                    Html.fromHtml(it.activityScan, Html.FROM_HTML_MODE_LEGACY).toString(),
+                    adjustedDate,
+                    it.location,
+                )
+            }
+
+        val status =
+            when (details.progressBarType) {
+                "ManifestUpload" -> Status.Preadvice
+                "FirstUPSPossession" -> Status.InTransit
+                "InTransit" -> Status.InTransit
+                "OutForDelivery" -> Status.OutForDelivery
+                "Delivered" -> Status.Delivered
+                "Exception" -> Status.DeliveryFailure
+                else -> logUnknownStatus("UPS", details.progressBarType!!)
+            }
+
+        val metadata = mutableMapOf<Int, String>()
+        if (details.additionalInformation?.weightUnit != null) {
+            metadata[R.string.property_weight] =
+                "${details.additionalInformation.weight} ${details.additionalInformation.weightUnit}"
         }
 
-    val status =
-        when (details.progressBarType) {
-          "ManifestUpload" -> Status.Preadvice
-          "FirstUPSPossession" -> Status.InTransit
-          "InTransit" -> Status.InTransit
-          "OutForDelivery" -> Status.OutForDelivery
-          "Delivered" -> Status.Delivered
-          "Exception" -> Status.DeliveryFailure
-          else -> logUnknownStatus("UPS", details.progressBarType!!)
+        // ETA
+        if (details.scheduledDeliveryDateDetail != null && details.packageStatusTime != null) {
+            val month =
+                when (details.scheduledDeliveryDateDetail.monthCMSKey) {
+                    "cms.stapp.jan" -> 1
+                    "cms.stapp.feb" -> 2
+                    "cms.stapp.mar" -> 3
+                    "cms.stapp.apr" -> 4
+                    "cms.stapp.may" -> 5
+                    "cms.stapp.jun" -> 6
+                    "cms.stapp.jul" -> 7
+                    "cms.stapp.aug" -> 8
+                    "cms.stapp.sep" -> 9
+                    "cms.stapp.oct" -> 10
+                    "cms.stapp.nov" -> 11
+                    "cms.stapp.dec" -> 12
+                    else -> 0
+                }
+            val day = details.scheduledDeliveryDateDetail.dayNum.toInt()
+            val date = LocalDate.now().withMonth(month).withDayOfMonth(day)
+            val eta =
+                (date?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)) +
+                    "\n"
+                    // cleanup A.M., P.M. -> AM, PM
+                    +
+                    details.packageStatusTime.replace(".M.", "M"))
+            metadata[R.string.property_eta] = eta
         }
 
-    val metadata = mutableMapOf<Int, String>()
-    if (details.additionalInformation?.weightUnit != null) {
-      metadata[R.string.property_weight] =
-          "${details.additionalInformation.weight} ${details.additionalInformation.weightUnit}"
+        return Parcel(trackingId, history, status, metadata)
     }
 
-    // ETA
-    if (details.scheduledDeliveryDateDetail != null && details.packageStatusTime != null) {
-      val month =
-          when (details.scheduledDeliveryDateDetail.monthCMSKey) {
-            "cms.stapp.jan" -> 1
-            "cms.stapp.feb" -> 2
-            "cms.stapp.mar" -> 3
-            "cms.stapp.apr" -> 4
-            "cms.stapp.may" -> 5
-            "cms.stapp.jun" -> 6
-            "cms.stapp.jul" -> 7
-            "cms.stapp.aug" -> 8
-            "cms.stapp.sep" -> 9
-            "cms.stapp.oct" -> 10
-            "cms.stapp.nov" -> 11
-            "cms.stapp.dec" -> 12
-            else -> 0
-          }
-      val day = details.scheduledDeliveryDateDetail.dayNum.toInt()
-      val date = LocalDate.now().withMonth(month).withDayOfMonth(day)
-      val eta =
-          (date?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)) +
-              "\n"
-              // cleanup A.M., P.M. -> AM, PM
-              +
-              details.packageStatusTime.replace(".M.", "M"))
-      metadata[R.string.property_eta] = eta
-    }
-
-    return Parcel(trackingId, history, status, metadata)
-  }
-
-  private val retrofit =
-      Retrofit.Builder()
-          .baseUrl("https://webapis.ups.com/track/api/")
-          .client(api_client)
-          .addConverterFactory(api_factory)
-          .build()
-
-  private val service = retrofit.create(API::class.java)
-
-  private interface API {
-    @Headers(
-        "accept: application/json, text/plain, */*",
-        "accept-language: en-US,en;q=0.9",
-        "origin: https://www.ups.com",
-        "sec-ch-ua: \"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
-        "sec-ch-ua-mobile: ?0",
-        "sec-ch-ua-platform: \"Linux\"",
-        "sec-fetch-dest: empty",
-        "sec-fetch-mode: cors",
-        "sec-fetch-site: same-site",
-        "user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
-    )
-    @POST("Track/GetStatus")
-    suspend fun getStatus(
-        @Query("loc") locale: String = "en_US",
-        @Header("cookie") csrfTokenCookie: String,
-        @Header("x-xsrf-token") xsrfToken: String,
-        @Body data: GetStatusRequest
-    ): GetStatusResponse
-  }
-
-  @JsonClass(generateAdapter = true)
-  internal data class GetStatusRequest(
-      val Locale: String,
-      val TrackingNumber: List<String>,
-      val isBarcodeScanned: Boolean = false,
-      val Requester: String = "st",
-      val returnToValue: String = "",
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class GetStatusResponse(
-      val trackDetails: List<TrackDetails>?,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class TrackDetails(
-      val errorCode: String?,
-      val progressBarType: String?,
-      val additionalInformation: PkgMoreInfo?,
-      val shipmentProgressActivities: List<ActivityEntry>?,
-      val scheduledDeliveryDateDetail: DeliveryDateDetail?,
-      val packageStatusTime: String?,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class PkgMoreInfo(
-      val weight: String,
-      val weightUnit: String?,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class ActivityEntry(
-      val location: String,
-      val activityScan: String,
-      val gmtDate: String,
-      val gmtTime: String,
-  )
-
-  @JsonClass(generateAdapter = true)
-  internal data class DeliveryDateDetail(
-      val monthCMSKey: String,
-      val dayNum: String,
-  )
-
-  // Grabs the necessary tokens by making a request to the UPS website
-  @OptIn(ExperimentalCoroutinesApi::class)
-  private suspend fun getCsrfTokens(trackingId: String): Pair<String, String> {
-    val request =
-        Request.Builder()
-            .addHeader("accept", "*/*")
-            .addHeader("accept-language", "en-US,en;q=0.9")
-            .addHeader(
-                "sec-ch-ua",
-                "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"")
-            .addHeader("sec-ch-ua-mobile", "?0")
-            .addHeader("sec-ch-ua-platform", "\"Linux\"")
-            .addHeader("sec-fetch-dest", "empty")
-            .addHeader("sec-fetch-mode", "cors")
-            .addHeader("sec-fetch-site", "same-site")
-            .addHeader(
-                "user-agent",
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36")
-            .url("https://www.ups.com/track?tracknum=${trackingId.lowercase()}")
+    private val retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://webapis.ups.com/track/api/")
+            .client(api_client)
+            .addConverterFactory(api_factory)
             .build()
 
-    api_client.newCall(request).executeAsync().use { response ->
-      Log.d("UPS", "Got response")
-      var csrfToken = ""
-      var xsrfToken = ""
-      for (pair in response.headers) {
-        if (pair.first.lowercase() == "set-cookie") {
-          if (pair.second.startsWith("X-CSRF-TOKEN=")) {
-            csrfToken = pair.second.split('=')[1].split(';')[0]
-            Log.d("UPS", "Got CSRF token: $csrfToken")
-          }
-          if (pair.second.startsWith("X-XSRF-TOKEN-ST=")) {
-            xsrfToken = pair.second.split('=')[1].split(';')[0]
-            Log.d("UPS", "Got XSRF token: $xsrfToken")
-          }
-        }
-      }
-      return Pair(csrfToken, xsrfToken)
+    private val service = retrofit.create(API::class.java)
+
+    private interface API {
+        @Headers(
+            "accept: application/json, text/plain, */*",
+            "accept-language: en-US,en;q=0.9",
+            "origin: https://www.ups.com",
+            "sec-ch-ua: \"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
+            "sec-ch-ua-mobile: ?0",
+            "sec-ch-ua-platform: \"Linux\"",
+            "sec-fetch-dest: empty",
+            "sec-fetch-mode: cors",
+            "sec-fetch-site: same-site",
+            "user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        )
+        @POST("Track/GetStatus")
+        suspend fun getStatus(
+            @Query("loc") locale: String = "en_US",
+            @Header("cookie") csrfTokenCookie: String,
+            @Header("x-xsrf-token") xsrfToken: String,
+            @Body data: GetStatusRequest,
+        ): GetStatusResponse
     }
 
-    return Pair("", "")
-  }
+    @JsonClass(generateAdapter = true)
+    internal data class GetStatusRequest(
+        val Locale: String,
+        val TrackingNumber: List<String>,
+        val isBarcodeScanned: Boolean = false,
+        val Requester: String = "st",
+        val returnToValue: String = "",
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class GetStatusResponse(val trackDetails: List<TrackDetails>?)
+
+    @JsonClass(generateAdapter = true)
+    internal data class TrackDetails(
+        val errorCode: String?,
+        val progressBarType: String?,
+        val additionalInformation: PkgMoreInfo?,
+        val shipmentProgressActivities: List<ActivityEntry>?,
+        val scheduledDeliveryDateDetail: DeliveryDateDetail?,
+        val packageStatusTime: String?,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class PkgMoreInfo(val weight: String, val weightUnit: String?)
+
+    @JsonClass(generateAdapter = true)
+    internal data class ActivityEntry(
+        val location: String,
+        val activityScan: String,
+        val gmtDate: String,
+        val gmtTime: String,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class DeliveryDateDetail(val monthCMSKey: String, val dayNum: String)
+
+    // Grabs the necessary tokens by making a request to the UPS website
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun getCsrfTokens(trackingId: String): Pair<String, String> {
+        val request =
+            Request.Builder()
+                .addHeader("accept", "*/*")
+                .addHeader("accept-language", "en-US,en;q=0.9")
+                .addHeader(
+                    "sec-ch-ua",
+                    "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
+                )
+                .addHeader("sec-ch-ua-mobile", "?0")
+                .addHeader("sec-ch-ua-platform", "\"Linux\"")
+                .addHeader("sec-fetch-dest", "empty")
+                .addHeader("sec-fetch-mode", "cors")
+                .addHeader("sec-fetch-site", "same-site")
+                .addHeader(
+                    "user-agent",
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+                )
+                .url("https://www.ups.com/track?tracknum=${trackingId.lowercase()}")
+                .build()
+
+        api_client.newCall(request).executeAsync().use { response ->
+            Log.d("UPS", "Got response")
+            var csrfToken = ""
+            var xsrfToken = ""
+            for (pair in response.headers) {
+                if (pair.first.lowercase() == "set-cookie") {
+                    if (pair.second.startsWith("X-CSRF-TOKEN=")) {
+                        csrfToken = pair.second.split('=')[1].split(';')[0]
+                        Log.d("UPS", "Got CSRF token: $csrfToken")
+                    }
+                    if (pair.second.startsWith("X-XSRF-TOKEN-ST=")) {
+                        xsrfToken = pair.second.split('=')[1].split(';')[0]
+                        Log.d("UPS", "Got XSRF token: $xsrfToken")
+                    }
+                }
+            }
+            return Pair(csrfToken, xsrfToken)
+        }
+
+        return Pair("", "")
+    }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/ui/views/AddEditParcelView.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/ui/views/AddEditParcelView.kt
@@ -51,237 +51,254 @@ import dev.itsvic.parceltracker.ui.theme.ParcelTrackerTheme
 @Composable
 fun AddEditParcelView(
     parcel: Parcel?,
+    prefillService: Service = Service.UNDEFINED,
+    prefillTrackingId: String = "",
+    prefillPostalCode: String = "",
     onBackPressed: () -> Unit,
     onCompleted: (Parcel) -> Unit,
 ) {
-  val isEdit = parcel != null
+    val isEdit = parcel != null
 
-  var humanName by remember { mutableStateOf(parcel?.humanName ?: "") }
-  var nameError by remember { mutableStateOf(false) }
-  var trackingId by remember { mutableStateOf(parcel?.parcelId ?: "") }
-  var idError by remember { mutableStateOf(false) }
-  var specifyPostalCode by remember { mutableStateOf(parcel?.postalCode != null) }
-  var postalCode by remember { mutableStateOf(parcel?.postalCode ?: "") }
-  var postalCodeError by remember { mutableStateOf(false) }
-  var service by remember { mutableStateOf(parcel?.service ?: Service.UNDEFINED) }
-  var serviceError by remember { mutableStateOf(false) }
-
-  val backend = if (service != Service.UNDEFINED) getDeliveryService(service) else null
-
-  fun validateInputs(): Boolean {
-    // reset error states first
-    nameError = false
-    idError = false
-    serviceError = false
-    postalCodeError = false
-
-    var success = true
-    if (humanName.isBlank()) {
-      success = false
-      nameError = true
+    var humanName by remember { mutableStateOf(parcel?.humanName ?: "") }
+    var nameError by remember { mutableStateOf(false) }
+    var trackingId by remember { mutableStateOf(parcel?.parcelId ?: prefillTrackingId) }
+    var idError by remember { mutableStateOf(false) }
+    var specifyPostalCode by remember {
+        mutableStateOf(parcel?.postalCode != null || prefillPostalCode.isNotBlank())
     }
-    if (trackingId.isBlank()) {
-      success = false
-      idError = true
+    var postalCode by remember { mutableStateOf(parcel?.postalCode ?: prefillPostalCode) }
+    var postalCodeError by remember { mutableStateOf(false) }
+    var service by remember { mutableStateOf(parcel?.service ?: prefillService) }
+    var serviceError by remember { mutableStateOf(false) }
+
+    val backend = if (service != Service.UNDEFINED) getDeliveryService(service) else null
+
+    fun validateInputs(): Boolean {
+        // reset error states first
+        nameError = false
+        idError = false
+        serviceError = false
+        postalCodeError = false
+
+        var success = true
+        if (humanName.isBlank()) {
+            success = false
+            nameError = true
+        }
+        if (trackingId.isBlank()) {
+            success = false
+            idError = true
+        }
+        if (service == Service.UNDEFINED) {
+            success = false
+            serviceError = true
+        }
+        if (
+            ((backend?.acceptsPostCode == true && specifyPostalCode) ||
+                (backend?.requiresPostCode == true)) && postalCode.isBlank()
+        ) {
+            success = false
+            postalCodeError = true
+        }
+
+        if (!success) return false
+        return true
     }
-    if (service == Service.UNDEFINED) {
-      success = false
-      serviceError = true
-    }
-    if (((backend?.acceptsPostCode == true && specifyPostalCode) ||
-        (backend?.requiresPostCode == true)) && postalCode.isBlank()) {
-      success = false
-      postalCodeError = true
-    }
 
-    if (!success) return false
-    return true
-  }
+    var expanded by remember { mutableStateOf(false) }
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
-  var expanded by remember { mutableStateOf(false) }
-  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    val sortedServiceOptions =
+        serviceOptions.sortedBy { getDeliveryService(it)?.acceptsFormat(trackingId)?.not() }
 
-  val sortedServiceOptions =
-      serviceOptions.sortedBy { getDeliveryService(it)?.acceptsFormat(trackingId)?.not() }
-
-  Scaffold(
-      topBar = {
-        TopAppBar(
-            title = {
-              Text(stringResource(if (isEdit) R.string.edit_parcel else R.string.add_a_parcel))
-            },
-            navigationIcon = {
-              IconButton(onClick = onBackPressed) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.go_back))
-              }
-            },
-            scrollBehavior = scrollBehavior,
-        )
-      },
-      modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)) { innerPadding ->
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        stringResource(if (isEdit) R.string.edit_parcel else R.string.add_a_parcel)
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.go_back))
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    ) { innerPadding ->
         Column(
             modifier =
                 Modifier.padding(innerPadding).fillMaxWidth().verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              Column(
-                  modifier =
-                      Modifier.padding(horizontal = 16.dp).sizeIn(maxWidth = 488.dp).fillMaxWidth(),
-                  verticalArrangement = Arrangement.spacedBy(8.dp),
-              ) {
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Column(
+                modifier =
+                    Modifier.padding(horizontal = 16.dp).sizeIn(maxWidth = 488.dp).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 OutlinedTextField(
                     value = humanName,
                     onValueChange = {
-                      humanName = it
-                      nameError = false
+                        humanName = it
+                        nameError = false
                     },
                     singleLine = true,
                     label = { Text(stringResource(R.string.parcel_name)) },
                     modifier = Modifier.fillMaxWidth(),
                     isError = nameError,
                     supportingText = {
-                      if (nameError) Text(stringResource(R.string.human_name_error_text))
-                    })
+                        if (nameError) Text(stringResource(R.string.human_name_error_text))
+                    },
+                )
 
                 OutlinedTextField(
                     value = trackingId,
                     onValueChange = {
-                      trackingId = it
-                      idError = false
+                        trackingId = it
+                        idError = false
                     },
                     singleLine = true,
                     label = { Text(stringResource(R.string.tracking_id)) },
                     modifier = Modifier.fillMaxWidth(),
                     isError = idError,
                     supportingText = {
-                      if (idError) Text(stringResource(R.string.tracking_id_error_text))
-                    })
+                        if (idError) Text(stringResource(R.string.tracking_id_error_text))
+                    },
+                )
 
                 // Service dropdown
-                ExposedDropdownMenuBox(
-                    expanded = expanded,
-                    onExpandedChange = { expanded = it },
-                ) {
-                  OutlinedTextField(
-                      value =
-                          if (service == Service.UNDEFINED) ""
-                          else stringResource(getDeliveryServiceName(service)!!),
-                      onValueChange = {},
-                      modifier =
-                          Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                              .fillMaxWidth(),
-                      readOnly = true,
-                      label = { Text(stringResource(R.string.delivery_service)) },
-                      trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
-                      colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
-                      isError = serviceError,
-                      supportingText = {
-                        if (serviceError) Text(stringResource(R.string.service_error_text))
-                      })
+                ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                    OutlinedTextField(
+                        value =
+                            if (service == Service.UNDEFINED) ""
+                            else stringResource(getDeliveryServiceName(service)!!),
+                        onValueChange = {},
+                        modifier =
+                            Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                                .fillMaxWidth(),
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.delivery_service)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                        isError = serviceError,
+                        supportingText = {
+                            if (serviceError) Text(stringResource(R.string.service_error_text))
+                        },
+                    )
 
-                  ExposedDropdownMenu(
-                      expanded = expanded, onDismissRequest = { expanded = false }) {
+                    ExposedDropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                    ) {
                         sortedServiceOptions.forEach { option ->
-                          DropdownMenuItem(
-                              text = { Text(stringResource(getDeliveryServiceName(option)!!)) },
-                              onClick = {
-                                service = option
-                                expanded = false
-                                serviceError = false
-                              },
-                              contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
-                          )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(getDeliveryServiceName(option)!!)) },
+                                onClick = {
+                                    service = option
+                                    expanded = false
+                                    serviceError = false
+                                },
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                            )
                         }
-                      }
+                    }
                 }
 
                 AnimatedVisibility(backend?.acceptsPostCode == true && !backend.requiresPostCode) {
-                  Row(
-                      verticalAlignment = Alignment.CenterVertically,
-                      horizontalArrangement = Arrangement.SpaceBetween,
-                      modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
                         Column(modifier = Modifier.fillMaxWidth(0.8f)) {
-                          Text(stringResource(R.string.specify_a_postal_code))
-                          Text(
-                              stringResource(R.string.specify_postal_code_flavor_text),
-                              fontSize = 14.sp,
-                              lineHeight = 21.sp,
-                              color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(stringResource(R.string.specify_a_postal_code))
+                            Text(
+                                stringResource(R.string.specify_postal_code_flavor_text),
+                                fontSize = 14.sp,
+                                lineHeight = 21.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
                         }
                         Checkbox(
                             checked = specifyPostalCode,
                             onCheckedChange = { specifyPostalCode = it },
                         )
-                      }
+                    }
                 }
 
                 AnimatedVisibility(
                     backend?.requiresPostCode == true ||
                         (backend?.requiresPostCode == false &&
                             backend.acceptsPostCode &&
-                            specifyPostalCode)) {
-                      OutlinedTextField(
-                          value = postalCode,
-                          onValueChange = {
+                            specifyPostalCode)
+                ) {
+                    OutlinedTextField(
+                        value = postalCode,
+                        onValueChange = {
                             postalCode = it
                             postalCodeError = false
-                          },
-                          singleLine = true,
-                          label = { Text(stringResource(R.string.postal_code)) },
-                          modifier = Modifier.fillMaxWidth(),
-                          isError = postalCodeError,
-                          supportingText = {
+                        },
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.postal_code)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        isError = postalCodeError,
+                        supportingText = {
                             if (postalCodeError)
                                 Text(stringResource(R.string.postal_code_error_text))
-                          })
-                    }
+                        },
+                    )
+                }
 
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
-                  Button(
-                      onClick = {
-                        val isOk = validateInputs()
-                        if (isOk) {
-                          // data valid, pass it along
-                          onCompleted(
-                              Parcel(
-                                  id = parcel?.id ?: 0,
-                                  humanName = humanName,
-                                  parcelId = trackingId,
-                                  service = service,
-                                  postalCode =
-                                      if (backend?.requiresPostCode == true ||
-                                          (backend?.acceptsPostCode == true && specifyPostalCode))
-                                          postalCode
-                                      else null))
+                    Button(
+                        onClick = {
+                            val isOk = validateInputs()
+                            if (isOk) {
+                                // data valid, pass it along
+                                onCompleted(
+                                    Parcel(
+                                        id = parcel?.id ?: 0,
+                                        humanName = humanName,
+                                        parcelId = trackingId,
+                                        service = service,
+                                        postalCode =
+                                            if (
+                                                backend?.requiresPostCode == true ||
+                                                    (backend?.acceptsPostCode == true &&
+                                                        specifyPostalCode)
+                                            )
+                                                postalCode
+                                            else null,
+                                    )
+                                )
+                            }
                         }
-                      }) {
+                    ) {
                         Text(stringResource(if (isEdit) R.string.save else R.string.add_parcel))
-                      }
+                    }
                 }
-              }
             }
-      }
+        }
+    }
 }
 
 @Composable
 @PreviewLightDark
 fun AddParcelPreview() {
-  ParcelTrackerTheme {
-    AddEditParcelView(
-        null,
-        onBackPressed = {},
-        onCompleted = {},
-    )
-  }
+    ParcelTrackerTheme { AddEditParcelView(null, onBackPressed = {}, onCompleted = {}) }
 }
 
 @Composable
 @PreviewLightDark
 fun EditParcelPreview() {
-  ParcelTrackerTheme {
-    AddEditParcelView(
-        Parcel(0, "Test", "Test", null, Service.EXAMPLE),
-        onBackPressed = {},
-        onCompleted = {},
-    )
-  }
+    ParcelTrackerTheme {
+        AddEditParcelView(
+            Parcel(0, "Test", "Test", null, Service.EXAMPLE),
+            onBackPressed = {},
+            onCompleted = {},
+        )
+    }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/ui/views/AddEditParcelView.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/ui/views/AddEditParcelView.kt
@@ -57,248 +57,234 @@ fun AddEditParcelView(
     onBackPressed: () -> Unit,
     onCompleted: (Parcel) -> Unit,
 ) {
-    val isEdit = parcel != null
+  val isEdit = parcel != null
 
-    var humanName by remember { mutableStateOf(parcel?.humanName ?: "") }
-    var nameError by remember { mutableStateOf(false) }
-    var trackingId by remember { mutableStateOf(parcel?.parcelId ?: prefillTrackingId) }
-    var idError by remember { mutableStateOf(false) }
-    var specifyPostalCode by remember {
-        mutableStateOf(parcel?.postalCode != null || prefillPostalCode.isNotBlank())
+  var humanName by remember { mutableStateOf(parcel?.humanName ?: "") }
+  var nameError by remember { mutableStateOf(false) }
+  var trackingId by remember { mutableStateOf(parcel?.parcelId ?: prefillTrackingId) }
+  var idError by remember { mutableStateOf(false) }
+  var specifyPostalCode by remember {
+    mutableStateOf(parcel?.postalCode != null || prefillPostalCode.isNotBlank())
+  }
+  var postalCode by remember { mutableStateOf(parcel?.postalCode ?: prefillPostalCode) }
+  var postalCodeError by remember { mutableStateOf(false) }
+  var service by remember { mutableStateOf(parcel?.service ?: prefillService) }
+  var serviceError by remember { mutableStateOf(false) }
+
+  val backend = if (service != Service.UNDEFINED) getDeliveryService(service) else null
+
+  fun validateInputs(): Boolean {
+    // reset error states first
+    nameError = false
+    idError = false
+    serviceError = false
+    postalCodeError = false
+
+    var success = true
+    if (humanName.isBlank()) {
+      success = false
+      nameError = true
     }
-    var postalCode by remember { mutableStateOf(parcel?.postalCode ?: prefillPostalCode) }
-    var postalCodeError by remember { mutableStateOf(false) }
-    var service by remember { mutableStateOf(parcel?.service ?: prefillService) }
-    var serviceError by remember { mutableStateOf(false) }
-
-    val backend = if (service != Service.UNDEFINED) getDeliveryService(service) else null
-
-    fun validateInputs(): Boolean {
-        // reset error states first
-        nameError = false
-        idError = false
-        serviceError = false
-        postalCodeError = false
-
-        var success = true
-        if (humanName.isBlank()) {
-            success = false
-            nameError = true
-        }
-        if (trackingId.isBlank()) {
-            success = false
-            idError = true
-        }
-        if (service == Service.UNDEFINED) {
-            success = false
-            serviceError = true
-        }
-        if (
-            ((backend?.acceptsPostCode == true && specifyPostalCode) ||
-                (backend?.requiresPostCode == true)) && postalCode.isBlank()
-        ) {
-            success = false
-            postalCodeError = true
-        }
-
-        if (!success) return false
-        return true
+    if (trackingId.isBlank()) {
+      success = false
+      idError = true
+    }
+    if (service == Service.UNDEFINED) {
+      success = false
+      serviceError = true
+    }
+    if (((backend?.acceptsPostCode == true && specifyPostalCode) ||
+        (backend?.requiresPostCode == true)) && postalCode.isBlank()) {
+      success = false
+      postalCodeError = true
     }
 
-    var expanded by remember { mutableStateOf(false) }
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    if (!success) return false
+    return true
+  }
 
-    val sortedServiceOptions =
-        serviceOptions.sortedBy { getDeliveryService(it)?.acceptsFormat(trackingId)?.not() }
+  var expanded by remember { mutableStateOf(false) }
+  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        stringResource(if (isEdit) R.string.edit_parcel else R.string.add_a_parcel)
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.go_back))
-                    }
-                },
-                scrollBehavior = scrollBehavior,
-            )
-        },
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-    ) { innerPadding ->
-        Column(
-            modifier =
-                Modifier.padding(innerPadding).fillMaxWidth().verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Column(
-                modifier =
-                    Modifier.padding(horizontal = 16.dp).sizeIn(maxWidth = 488.dp).fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedTextField(
-                    value = humanName,
-                    onValueChange = {
-                        humanName = it
-                        nameError = false
-                    },
-                    singleLine = true,
-                    label = { Text(stringResource(R.string.parcel_name)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = nameError,
-                    supportingText = {
-                        if (nameError) Text(stringResource(R.string.human_name_error_text))
-                    },
-                )
+  val sortedServiceOptions =
+      serviceOptions.sortedBy { getDeliveryService(it)?.acceptsFormat(trackingId)?.not() }
 
-                OutlinedTextField(
-                    value = trackingId,
-                    onValueChange = {
-                        trackingId = it
-                        idError = false
-                    },
-                    singleLine = true,
-                    label = { Text(stringResource(R.string.tracking_id)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = idError,
-                    supportingText = {
-                        if (idError) Text(stringResource(R.string.tracking_id_error_text))
-                    },
-                )
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Text(stringResource(if (isEdit) R.string.edit_parcel else R.string.add_a_parcel))
+            },
+            navigationIcon = {
+              IconButton(onClick = onBackPressed) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.go_back))
+              }
+            },
+            scrollBehavior = scrollBehavior,
+        )
+      },
+      modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+  ) { innerPadding ->
+    Column(
+        modifier =
+            Modifier.padding(innerPadding).fillMaxWidth().verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Column(
+          modifier = Modifier.padding(horizontal = 16.dp).sizeIn(maxWidth = 488.dp).fillMaxWidth(),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        OutlinedTextField(
+            value = humanName,
+            onValueChange = {
+              humanName = it
+              nameError = false
+            },
+            singleLine = true,
+            label = { Text(stringResource(R.string.parcel_name)) },
+            modifier = Modifier.fillMaxWidth(),
+            isError = nameError,
+            supportingText = {
+              if (nameError) Text(stringResource(R.string.human_name_error_text))
+            },
+        )
 
-                // Service dropdown
-                ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
-                    OutlinedTextField(
-                        value =
-                            if (service == Service.UNDEFINED) ""
-                            else stringResource(getDeliveryServiceName(service)!!),
-                        onValueChange = {},
-                        modifier =
-                            Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                                .fillMaxWidth(),
-                        readOnly = true,
-                        label = { Text(stringResource(R.string.delivery_service)) },
-                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
-                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
-                        isError = serviceError,
-                        supportingText = {
-                            if (serviceError) Text(stringResource(R.string.service_error_text))
-                        },
-                    )
+        OutlinedTextField(
+            value = trackingId,
+            onValueChange = {
+              trackingId = it
+              idError = false
+            },
+            singleLine = true,
+            label = { Text(stringResource(R.string.tracking_id)) },
+            modifier = Modifier.fillMaxWidth(),
+            isError = idError,
+            supportingText = { if (idError) Text(stringResource(R.string.tracking_id_error_text)) },
+        )
 
-                    ExposedDropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false },
-                    ) {
-                        sortedServiceOptions.forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(stringResource(getDeliveryServiceName(option)!!)) },
-                                onClick = {
-                                    service = option
-                                    expanded = false
-                                    serviceError = false
-                                },
-                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
-                            )
-                        }
-                    }
-                }
+        // Service dropdown
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+          OutlinedTextField(
+              value =
+                  if (service == Service.UNDEFINED) ""
+                  else stringResource(getDeliveryServiceName(service)!!),
+              onValueChange = {},
+              modifier =
+                  Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                      .fillMaxWidth(),
+              readOnly = true,
+              label = { Text(stringResource(R.string.delivery_service)) },
+              trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+              colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+              isError = serviceError,
+              supportingText = {
+                if (serviceError) Text(stringResource(R.string.service_error_text))
+              },
+          )
 
-                AnimatedVisibility(backend?.acceptsPostCode == true && !backend.requiresPostCode) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Column(modifier = Modifier.fillMaxWidth(0.8f)) {
-                            Text(stringResource(R.string.specify_a_postal_code))
-                            Text(
-                                stringResource(R.string.specify_postal_code_flavor_text),
-                                fontSize = 14.sp,
-                                lineHeight = 21.sp,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        Checkbox(
-                            checked = specifyPostalCode,
-                            onCheckedChange = { specifyPostalCode = it },
-                        )
-                    }
-                }
-
-                AnimatedVisibility(
-                    backend?.requiresPostCode == true ||
-                        (backend?.requiresPostCode == false &&
-                            backend.acceptsPostCode &&
-                            specifyPostalCode)
-                ) {
-                    OutlinedTextField(
-                        value = postalCode,
-                        onValueChange = {
-                            postalCode = it
-                            postalCodeError = false
-                        },
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.postal_code)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        isError = postalCodeError,
-                        supportingText = {
-                            if (postalCodeError)
-                                Text(stringResource(R.string.postal_code_error_text))
-                        },
-                    )
-                }
-
-                Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
-                    Button(
-                        onClick = {
-                            val isOk = validateInputs()
-                            if (isOk) {
-                                // data valid, pass it along
-                                onCompleted(
-                                    Parcel(
-                                        id = parcel?.id ?: 0,
-                                        humanName = humanName,
-                                        parcelId = trackingId,
-                                        service = service,
-                                        postalCode =
-                                            if (
-                                                backend?.requiresPostCode == true ||
-                                                    (backend?.acceptsPostCode == true &&
-                                                        specifyPostalCode)
-                                            )
-                                                postalCode
-                                            else null,
-                                    )
-                                )
-                            }
-                        }
-                    ) {
-                        Text(stringResource(if (isEdit) R.string.save else R.string.add_parcel))
-                    }
-                }
+          ExposedDropdownMenu(
+              expanded = expanded,
+              onDismissRequest = { expanded = false },
+          ) {
+            sortedServiceOptions.forEach { option ->
+              DropdownMenuItem(
+                  text = { Text(stringResource(getDeliveryServiceName(option)!!)) },
+                  onClick = {
+                    service = option
+                    expanded = false
+                    serviceError = false
+                  },
+                  contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+              )
             }
+          }
         }
+
+        AnimatedVisibility(backend?.acceptsPostCode == true && !backend.requiresPostCode) {
+          Row(
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.SpaceBetween,
+              modifier = Modifier.fillMaxWidth(),
+          ) {
+            Column(modifier = Modifier.fillMaxWidth(0.8f)) {
+              Text(stringResource(R.string.specify_a_postal_code))
+              Text(
+                  stringResource(R.string.specify_postal_code_flavor_text),
+                  fontSize = 14.sp,
+                  lineHeight = 21.sp,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+            Checkbox(
+                checked = specifyPostalCode,
+                onCheckedChange = { specifyPostalCode = it },
+            )
+          }
+        }
+
+        AnimatedVisibility(
+            backend?.requiresPostCode == true ||
+                (backend?.requiresPostCode == false &&
+                    backend.acceptsPostCode &&
+                    specifyPostalCode)) {
+              OutlinedTextField(
+                  value = postalCode,
+                  onValueChange = {
+                    postalCode = it
+                    postalCodeError = false
+                  },
+                  singleLine = true,
+                  label = { Text(stringResource(R.string.postal_code)) },
+                  modifier = Modifier.fillMaxWidth(),
+                  isError = postalCodeError,
+                  supportingText = {
+                    if (postalCodeError) Text(stringResource(R.string.postal_code_error_text))
+                  },
+              )
+            }
+
+        Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+          Button(
+              onClick = {
+                val isOk = validateInputs()
+                if (isOk) {
+                  // data valid, pass it along
+                  onCompleted(
+                      Parcel(
+                          id = parcel?.id ?: 0,
+                          humanName = humanName,
+                          parcelId = trackingId,
+                          service = service,
+                          postalCode =
+                              if (backend?.requiresPostCode == true ||
+                                  (backend?.acceptsPostCode == true && specifyPostalCode))
+                                  postalCode
+                              else null,
+                      ))
+                }
+              }) {
+                Text(stringResource(if (isEdit) R.string.save else R.string.add_parcel))
+              }
+        }
+      }
     }
+  }
 }
 
 @Composable
 @PreviewLightDark
 fun AddParcelPreview() {
-    ParcelTrackerTheme { AddEditParcelView(null, onBackPressed = {}, onCompleted = {}) }
+  ParcelTrackerTheme { AddEditParcelView(null, onBackPressed = {}, onCompleted = {}) }
 }
 
 @Composable
 @PreviewLightDark
 fun EditParcelPreview() {
-    ParcelTrackerTheme {
-        AddEditParcelView(
-            Parcel(0, "Test", "Test", null, Service.EXAMPLE),
-            onBackPressed = {},
-            onCompleted = {},
-        )
-    }
+  ParcelTrackerTheme {
+    AddEditParcelView(
+        Parcel(0, "Test", "Test", null, Service.EXAMPLE),
+        onBackPressed = {},
+        onCompleted = {},
+    )
+  }
 }

--- a/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
@@ -42,6 +42,15 @@ class TrackingUrlParserTest {
   }
 
   @Test
+  fun glsNetherlands_urlParsesToServiceTrackingIdAndPostalCode() {
+    assertEquals(
+        TrackingUrlMatch(Service.GLS_NETHERLANDS, "00000000000000", "1234AB"),
+        parseTrackingUrl(
+            "https://www.gls-info.nl/tracking/ttlink?parcelNo=00000000000000&zipCode=1234AB&lang=NL"),
+    )
+  }
+
+  @Test
   fun inpost_urlParsesToServiceAndTrackingId() {
     assertEquals(
         TrackingUrlMatch(Service.INPOST, "123456789012345678901234"),

--- a/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
@@ -8,126 +8,120 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class TrackingUrlParserTest {
-    @Test
-    fun dhlParcelNl_urlParsesToServiceAndTrackingId() {
-        assertEquals(
-            TrackingUrlMatch(Service.DHL, "JVGL00000000000000000000"),
-            parseTrackingUrl("https://my.dhlparcel.nl/go-track-trace?pid=JVGL00000000000000000000"),
-        )
-    }
+  @Test
+  fun dhlParcelNl_urlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.DHL, "JVGL00000000000000000000"),
+        parseTrackingUrl("https://my.dhlparcel.nl/go-track-trace?pid=JVGL00000000000000000000"),
+    )
+  }
 
-    @Test
-    fun ups_urlParsesToServiceAndTrackingId() {
-        assertEquals(
-            TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
-            parseTrackingUrl("https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"),
-        )
-    }
+  @Test
+  fun ups_urlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
+        parseTrackingUrl("https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"),
+    )
+  }
 
-    @Test
-    fun gls_urlParsesToServiceAndTrackingId() {
-        assertEquals(
-            TrackingUrlMatch(Service.GLS, "1234567890"),
-            parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?match=1234567890"),
-        )
-    }
+  @Test
+  fun gls_urlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.GLS, "1234567890"),
+        parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?match=1234567890"),
+    )
+  }
 
-    @Test
-    fun gls_countrySiteUrlParsesToServiceTrackingIdAndPostalCode() {
-        assertEquals(
-            TrackingUrlMatch(Service.GLS, "1234567890", "1234AB"),
-            parseTrackingUrl(
-                "https://www.gls-info.nl/tracking/ttlink?parcelNo=1234567890&zipCode=1234AB&lang=NL"
-            ),
-        )
-    }
+  @Test
+  fun gls_countrySiteUrlParsesToServiceTrackingIdAndPostalCode() {
+    assertEquals(
+        TrackingUrlMatch(Service.GLS, "1234567890", "1234AB"),
+        parseTrackingUrl(
+            "https://www.gls-info.nl/tracking/ttlink?parcelNo=1234567890&zipCode=1234AB&lang=NL"),
+    )
+  }
 
-    @Test
-    fun gls_otherCountryTldDoesNotMatch() {
-        // gls-info.nl is confirmed; other country TLDs are deliberately not supported
-        // since that generalization was never verified.
-        assertNull(
-            parseTrackingUrl(
-                "https://www.gls-info.de/tracking/ttlink?parcelNo=1234567890&zipCode=12345"
-            )
-        )
-    }
+  @Test
+  fun gls_otherCountryTldDoesNotMatch() {
+    // gls-info.nl is confirmed; other country TLDs are deliberately not supported
+    // since that generalization was never verified.
+    assertNull(
+        parseTrackingUrl(
+            "https://www.gls-info.de/tracking/ttlink?parcelNo=1234567890&zipCode=12345"))
+  }
 
-    @Test
-    fun inpost_urlParsesToServiceAndTrackingId() {
-        assertEquals(
-            TrackingUrlMatch(Service.INPOST, "123456789012345678901234"),
-            parseTrackingUrl("https://inpost.pl/en/tracking?number=123456789012345678901234"),
-        )
-    }
+  @Test
+  fun inpost_urlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.INPOST, "123456789012345678901234"),
+        parseTrackingUrl("https://inpost.pl/en/tracking?number=123456789012345678901234"),
+    )
+  }
 
-    @Test
-    fun postNL_pathUrlParsesToServiceTrackingIdAndPostalCode() {
-        assertEquals(
-            TrackingUrlMatch(Service.POST_NL, "3SABCD1234567", "1234AB"),
-            parseTrackingUrl("https://jouw.postnl.nl/track-and-trace/3SABCD1234567-NL-1234AB"),
-        )
-    }
+  @Test
+  fun postNL_pathUrlParsesToServiceTrackingIdAndPostalCode() {
+    assertEquals(
+        TrackingUrlMatch(Service.POST_NL, "3SABCD1234567", "1234AB"),
+        parseTrackingUrl("https://jouw.postnl.nl/track-and-trace/3SABCD1234567-NL-1234AB"),
+    )
+  }
 
-    @Test
-    fun polishPost_urlParsesToServiceAndTrackingId() {
-        assertEquals(
-            TrackingUrlMatch(Service.POLISH_POST, "PX1234567890"),
-            parseTrackingUrl("https://emonitoring.poczta-polska.pl/?numer=PX1234567890"),
-        )
-    }
+  @Test
+  fun polishPost_urlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.POLISH_POST, "PX1234567890"),
+        parseTrackingUrl("https://emonitoring.poczta-polska.pl/?numer=PX1234567890"),
+    )
+  }
 
-    // Providers without a confirmed tracking URL format have no trackingUrlPatterns
-    // and always fall through to null (which the UI treats as "open a blank Add
-    // Parcel form"). A couple of generic cases cover that fallback path.
+  // Providers without a confirmed tracking URL format have no trackingUrlPatterns
+  // and always fall through to null (which the UI treats as "open a blank Add
+  // Parcel form"). A couple of generic cases cover that fallback path.
 
-    @Test
-    fun unknownHost_returnsNull() {
-        assertNull(parseTrackingUrl("https://example.com/track?tracking-id=1234567890"))
-    }
+  @Test
+  fun unknownHost_returnsNull() {
+    assertNull(parseTrackingUrl("https://example.com/track?tracking-id=1234567890"))
+  }
 
-    @Test
-    fun knownHostWrongParam_returnsNull() {
-        assertNull(parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?foo=1234567890"))
-    }
+  @Test
+  fun knownHostWrongParam_returnsNull() {
+    assertNull(parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?foo=1234567890"))
+  }
 
-    @Test
-    fun postNord_obfuscatedWidgetLink_returnsNull() {
-        // Regression test: PostNord's real, documented shareable widget link uses an
-        // opaque id combining an API key and the shipment ID - it must never be
-        // mistaken for a real tracking number, even though we don't parse PostNord.
-        assertNull(
-            parseTrackingUrl(
-                "https://tracking.postnord.com/?id=06e097dd:6669:4a88:5159:bafa:40abc79c10ab1bf3:070SE"
-            )
-        )
-    }
+  @Test
+  fun postNord_obfuscatedWidgetLink_returnsNull() {
+    // Regression test: PostNord's real, documented shareable widget link uses an
+    // opaque id combining an API key and the shipment ID - it must never be
+    // mistaken for a real tracking number, even though we don't parse PostNord.
+    assertNull(
+        parseTrackingUrl(
+            "https://tracking.postnord.com/?id=06e097dd:6669:4a88:5159:bafa:40abc79c10ab1bf3:070SE"))
+  }
 
-    @Test
-    fun extractFirstUrl_pullsUrlOutOfSurroundingText() {
-        assertEquals(
-            "https://example.com/track?id=123",
-            extractFirstUrl("Track your parcel: https://example.com/track?id=123 Thanks!"),
-        )
-    }
+  @Test
+  fun extractFirstUrl_pullsUrlOutOfSurroundingText() {
+    assertEquals(
+        "https://example.com/track?id=123",
+        extractFirstUrl("Track your parcel: https://example.com/track?id=123 Thanks!"),
+    )
+  }
 
-    @Test
-    fun extractFirstUrl_returnsNullForPlainText() {
-        assertNull(extractFirstUrl("just some plain text, no link here"))
-    }
+  @Test
+  fun extractFirstUrl_returnsNullForPlainText() {
+    assertNull(extractFirstUrl("just some plain text, no link here"))
+  }
 
-    @Test
-    fun parseSharedText_combinesExtractionAndParsing() {
-        assertEquals(
-            TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
-            parseSharedText(
-                "Your UPS parcel is on its way: https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"
-            ),
-        )
-    }
+  @Test
+  fun parseSharedText_combinesExtractionAndParsing() {
+    assertEquals(
+        TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
+        parseSharedText(
+            "Your UPS parcel is on its way: https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"),
+    )
+  }
 
-    @Test
-    fun parseSharedText_returnsNullWhenNoUrlPresent() {
-        assertNull(parseSharedText("no link in this message"))
-    }
+  @Test
+  fun parseSharedText_returnsNullWhenNoUrlPresent() {
+    assertNull(parseSharedText("no link in this message"))
+  }
 }

--- a/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
@@ -1,0 +1,133 @@
+import dev.itsvic.parceltracker.api.Service
+import dev.itsvic.parceltracker.api.TrackingUrlMatch
+import dev.itsvic.parceltracker.api.extractFirstUrl
+import dev.itsvic.parceltracker.api.parseSharedText
+import dev.itsvic.parceltracker.api.parseTrackingUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TrackingUrlParserTest {
+    @Test
+    fun dhlParcelNl_urlParsesToServiceAndTrackingId() {
+        assertEquals(
+            TrackingUrlMatch(Service.DHL, "JVGL00000000000000000000"),
+            parseTrackingUrl("https://my.dhlparcel.nl/go-track-trace?pid=JVGL00000000000000000000"),
+        )
+    }
+
+    @Test
+    fun ups_urlParsesToServiceAndTrackingId() {
+        assertEquals(
+            TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
+            parseTrackingUrl("https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"),
+        )
+    }
+
+    @Test
+    fun gls_urlParsesToServiceAndTrackingId() {
+        assertEquals(
+            TrackingUrlMatch(Service.GLS, "1234567890"),
+            parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?match=1234567890"),
+        )
+    }
+
+    @Test
+    fun gls_countrySiteUrlParsesToServiceTrackingIdAndPostalCode() {
+        assertEquals(
+            TrackingUrlMatch(Service.GLS, "1234567890", "1234AB"),
+            parseTrackingUrl(
+                "https://www.gls-info.nl/tracking/ttlink?parcelNo=1234567890&zipCode=1234AB&lang=NL"
+            ),
+        )
+    }
+
+    @Test
+    fun gls_otherCountryTldDoesNotMatch() {
+        // gls-info.nl is confirmed; other country TLDs are deliberately not supported
+        // since that generalization was never verified.
+        assertNull(
+            parseTrackingUrl(
+                "https://www.gls-info.de/tracking/ttlink?parcelNo=1234567890&zipCode=12345"
+            )
+        )
+    }
+
+    @Test
+    fun inpost_urlParsesToServiceAndTrackingId() {
+        assertEquals(
+            TrackingUrlMatch(Service.INPOST, "123456789012345678901234"),
+            parseTrackingUrl("https://inpost.pl/en/tracking?number=123456789012345678901234"),
+        )
+    }
+
+    @Test
+    fun postNL_pathUrlParsesToServiceTrackingIdAndPostalCode() {
+        assertEquals(
+            TrackingUrlMatch(Service.POST_NL, "3SABCD1234567", "1234AB"),
+            parseTrackingUrl("https://jouw.postnl.nl/track-and-trace/3SABCD1234567-NL-1234AB"),
+        )
+    }
+
+    @Test
+    fun polishPost_urlParsesToServiceAndTrackingId() {
+        assertEquals(
+            TrackingUrlMatch(Service.POLISH_POST, "PX1234567890"),
+            parseTrackingUrl("https://emonitoring.poczta-polska.pl/?numer=PX1234567890"),
+        )
+    }
+
+    // Providers without a confirmed tracking URL format have no trackingUrlPatterns
+    // and always fall through to null (which the UI treats as "open a blank Add
+    // Parcel form"). A couple of generic cases cover that fallback path.
+
+    @Test
+    fun unknownHost_returnsNull() {
+        assertNull(parseTrackingUrl("https://example.com/track?tracking-id=1234567890"))
+    }
+
+    @Test
+    fun knownHostWrongParam_returnsNull() {
+        assertNull(parseTrackingUrl("https://gls-group.eu/EU/en/parcel-tracking?foo=1234567890"))
+    }
+
+    @Test
+    fun postNord_obfuscatedWidgetLink_returnsNull() {
+        // Regression test: PostNord's real, documented shareable widget link uses an
+        // opaque id combining an API key and the shipment ID - it must never be
+        // mistaken for a real tracking number, even though we don't parse PostNord.
+        assertNull(
+            parseTrackingUrl(
+                "https://tracking.postnord.com/?id=06e097dd:6669:4a88:5159:bafa:40abc79c10ab1bf3:070SE"
+            )
+        )
+    }
+
+    @Test
+    fun extractFirstUrl_pullsUrlOutOfSurroundingText() {
+        assertEquals(
+            "https://example.com/track?id=123",
+            extractFirstUrl("Track your parcel: https://example.com/track?id=123 Thanks!"),
+        )
+    }
+
+    @Test
+    fun extractFirstUrl_returnsNullForPlainText() {
+        assertNull(extractFirstUrl("just some plain text, no link here"))
+    }
+
+    @Test
+    fun parseSharedText_combinesExtractionAndParsing() {
+        assertEquals(
+            TrackingUrlMatch(Service.UPS, "1Z999AA10123456784"),
+            parseSharedText(
+                "Your UPS parcel is on its way: https://www.ups.com/track?loc=en_US&tracknum=1Z999AA10123456784"
+            ),
+        )
+    }
+
+    @Test
+    fun parseSharedText_returnsNullWhenNoUrlPresent() {
+        assertNull(parseSharedText("no link in this message"))
+    }
+}

--- a/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/TrackingUrlParserTest.kt
@@ -33,15 +33,6 @@ class TrackingUrlParserTest {
   }
 
   @Test
-  fun gls_countrySiteUrlParsesToServiceTrackingIdAndPostalCode() {
-    assertEquals(
-        TrackingUrlMatch(Service.GLS, "1234567890", "1234AB"),
-        parseTrackingUrl(
-            "https://www.gls-info.nl/tracking/ttlink?parcelNo=1234567890&zipCode=1234AB&lang=NL"),
-    )
-  }
-
-  @Test
   fun gls_otherCountryTldDoesNotMatch() {
     // gls-info.nl is confirmed; other country TLDs are deliberately not supported
     // since that generalization was never verified.
@@ -71,6 +62,46 @@ class TrackingUrlParserTest {
     assertEquals(
         TrackingUrlMatch(Service.POLISH_POST, "PX1234567890"),
         parseTrackingUrl("https://emonitoring.poczta-polska.pl/?numer=PX1234567890"),
+    )
+  }
+
+  @Test
+  fun samedayRomania_fragmentUrlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.SAMEDAY_RO, "1234567890123"),
+        parseTrackingUrl("https://sameday.ro/#awb=1234567890123"),
+    )
+  }
+
+  @Test
+  fun samedayRomania_statusPageUrlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.SAMEDAY_RO, "1234567890123"),
+        parseTrackingUrl("https://sameday.ro/status-colet/?awb=1234567890123"),
+    )
+  }
+
+  @Test
+  fun samedayHungary_fragmentUrlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.SAMEDAY_HU, "1234567890123"),
+        parseTrackingUrl("https://sameday.hu/#awb=1234567890123"),
+    )
+  }
+
+  @Test
+  fun samedayBulgaria_fragmentUrlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.SAMEDAY_BG, "1234567890123"),
+        parseTrackingUrl("https://sameday.bg/#awb=1234567890123"),
+    )
+  }
+
+  @Test
+  fun samedayBulgaria_statusPageUrlParsesToServiceAndTrackingId() {
+    assertEquals(
+        TrackingUrlMatch(Service.SAMEDAY_BG, "1234567890123"),
+        parseTrackingUrl("https://sameday.bg/status-na-pratkata/?awb=1234567890123"),
     )
   }
 

--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -3,6 +3,7 @@
 Některé funkce aplikace:
 
 - 📱 Čisté a jednoduché rozhraní: soustřeďte se na své zásilky, ne na to, jak používat aplikaci.
+- 🔗 Rychlé přidání: sdílejte sledovací odkaz v sekci „Zásilky“ nebo jej otevřete přímo a zásilku tak okamžitě přidejte.
 - 💬 Oznámení: získejte oznámení vždy, když se změní stav zásilky.
 - 🚫 Bez reklam a jiných nepříjemností.
 - 👥 Bezplatná a s otevřeným kódem: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -3,7 +3,6 @@
 Některé funkce aplikace:
 
 - 📱 Čisté a jednoduché rozhraní: soustřeďte se na své zásilky, ne na to, jak používat aplikaci.
-- 🔗 Rychlé přidání: sdílejte sledovací odkaz v sekci „Zásilky“ nebo jej otevřete přímo a zásilku tak okamžitě přidejte.
 - 💬 Oznámení: získejte oznámení vždy, když se změní stav zásilky.
 - 🚫 Bez reklam a jiných nepříjemností.
 - 👥 Bezplatná a s otevřeným kódem: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -1,8 +1,9 @@
 📦 Deliveries je aplikace, která vám pomáhá sledovat všechny vaše zásilky.
 
-Některé funkce aplikace:
+Některé funkce aplikace Deliveries:
 
 - 📱 Čisté a jednoduché rozhraní: soustřeďte se na své zásilky, ne na to, jak používat aplikaci.
+- 🔗 Rychlé přidání: sdílejte sledovací odkaz s aplikací Deliveries nebo jej přímo otevřete a zásilku okamžitě přidejte.
 - 💬 Oznámení: získejte oznámení vždy, když se změní stav zásilky.
 - 🚫 Bez reklam a jiných nepříjemností.
 - 👥 Bezplatná a s otevřeným kódem: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -3,7 +3,7 @@
 Einige Features von Deliveries:
 
 - 📱 Einfache Benutzeroberfläche: Fokussiere Dich auf Deine Pakete, nicht auf die Bedienung der App.
-- 🔗 Schnell hinzufügen: Teilen Sie einen Tracking-Link in „Lieferungen“ oder öffnen Sie einen direkt, um ein Paket sofort hinzuzufügen.
+- 🔗 Schnell hinzufügen: Teilen Sie einen Tracking-Link mit „Lieferungen“ oder öffnen Sie einen direkt, um ein Paket sofort hinzuzufügen.
 - 💬 Notifications: Erhalte Benachrichtigungen über jeden Fortschritt eines Paketes.
 - 🚫 Keine Werbung oder andere Irritationen.
 - 👥 Kostenlos und Open-Source: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -3,8 +3,8 @@
 Einige Features von Deliveries:
 
 - 📱 Einfache Benutzeroberfläche: Fokussiere Dich auf Deine Pakete, nicht auf die Bedienung der App.
-- 🔗 Schnell hinzufügen: Teilen Sie einen Tracking-Link mit „Lieferungen“ oder öffnen Sie einen direkt, um ein Paket sofort hinzuzufügen.
-- 💬 Notifications: Erhalte Benachrichtigungen über jeden Fortschritt eines Paketes.
+- 🔗 Schnell hinzufügen: Teile einen Tracking-Link mit „Deliveries“ oder öffne einen direkt, um ein Paket sofort hinzuzufügen.
+- 💬 Benachrichtigungen: Erhalte Benachrichtigungen über jeden Fortschritt eines Paketes.
 - 🚫 Keine Werbung oder andere Irritationen.
 - 👥 Kostenlos und Open-Source: https://github.com/itsvic-dev/parcel
 

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -3,6 +3,7 @@
 Einige Features von Deliveries:
 
 - 📱 Einfache Benutzeroberfläche: Fokussiere Dich auf Deine Pakete, nicht auf die Bedienung der App.
+- 🔗 Schnell hinzufügen: Teilen Sie einen Tracking-Link in „Lieferungen“ oder öffnen Sie einen direkt, um ein Paket sofort hinzuzufügen.
 - 💬 Notifications: Erhalte Benachrichtigungen über jeden Fortschritt eines Paketes.
 - 🚫 Keine Werbung oder andere Irritationen.
 - 👥 Kostenlos und Open-Source: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -3,6 +3,7 @@
 Some of Deliveries's features:
 
 - 📱 Clean and simple interface: Focus solely on your parcels, not how to use the app.
+- 🔗 Quick add: share a tracking link into Deliveries, or open one directly, to add a parcel instantly.
 - 💬 Notifications: Get notified every time a parcel progresses further.
 - 🚫 No ads or other annoyances.
 - 👥 Free and open-source: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/hu-HU/full_description.txt
+++ b/fastlane/metadata/android/hu-HU/full_description.txt
@@ -3,6 +3,7 @@
 Deliveries néhány funkciója:
 
 - 📱 Letisztult és egyszerű felület: fókuszálj a csomagjaidra, ne az app használatának elsajátítására.
+- 🔗 Gyors hozzáadás: ossz meg egy nyomkövetési linket a Deliveries alkalmazással, vagy nyisd meg közvetlenül a Deliveriesben, hogy azonnal hozzáadd a csomagot.
 - 💬 Értesítések: Értesülj a csomagjaid állapotának változásáról.
 - 🚫 Nincsenek reklámok vagy egyéb más zavaró dolgok.
 - 👥 Ingyenes és nyílt forráskódú: https://github.com/itsvic-dev/parcel
@@ -17,7 +18,7 @@ Nemzetközi:
 - GLS
 - UPS
 
-Észak Amerika:
+Észak-Amerika:
 
 - UniUni
 

--- a/fastlane/metadata/android/hu-HU/full_description.txt
+++ b/fastlane/metadata/android/hu-HU/full_description.txt
@@ -3,7 +3,6 @@
 Deliveries néhány funkciója:
 
 - 📱 Letisztult és egyszerű felület: fókuszálj a csomagjaidra, ne az app használatának elsajátítására.
-- 🔗 Gyors hozzáadás: ossz meg egy nyomonkövetési linket a „Szállítások” menüpontban, vagy nyisd meg közvetlenül, hogy azonnal hozzáadd a csomagot.
 - 💬 Értesítések: Értesülj a csomagjaid állapotának változásáról.
 - 🚫 Nincsenek reklámok vagy egyéb más zavaró dolgok.
 - 👥 Ingyenes és nyílt forráskódú: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/hu-HU/full_description.txt
+++ b/fastlane/metadata/android/hu-HU/full_description.txt
@@ -3,6 +3,7 @@
 Deliveries néhány funkciója:
 
 - 📱 Letisztult és egyszerű felület: fókuszálj a csomagjaidra, ne az app használatának elsajátítására.
+- 🔗 Gyors hozzáadás: ossz meg egy nyomonkövetési linket a „Szállítások” menüpontban, vagy nyisd meg közvetlenül, hogy azonnal hozzáadd a csomagot.
 - 💬 Értesítések: Értesülj a csomagjaid állapotának változásáról.
 - 🚫 Nincsenek reklámok vagy egyéb más zavaró dolgok.
 - 👥 Ingyenes és nyílt forráskódú: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/pl-PL/full_description.txt
+++ b/fastlane/metadata/android/pl-PL/full_description.txt
@@ -3,6 +3,7 @@
 Niektóre funkcje Deliveries:
 
 - 📱 Prosty i przejrzysty interfejs: Skup się wyłącznie na paczkach, a nie na tym, jak korzystać z aplikacji.
+- 🔗 Szybkie dodawanie: udostępnij link do śledzenia przesyłki w sekcji „Dostawy” lub otwórz go bezpośrednio, aby natychmiast dodać paczkę.
 - 💬 Powiadomienia: Otrzymuj powiadomienia za każdym razem, gdy paczka dotrze dalej.
 - 🚫 Żadnych reklam i innych irytacji.
 - 👥 Darmowe i otwarte oprogramowanie: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/pl-PL/full_description.txt
+++ b/fastlane/metadata/android/pl-PL/full_description.txt
@@ -3,6 +3,7 @@
 Niektóre funkcje Deliveries:
 
 - 📱 Prosty i przejrzysty interfejs: Skup się wyłącznie na paczkach, a nie na tym, jak korzystać z aplikacji.
+- 🔗 Szybkie dodawanie: udostępnij aplikacji Deliveries link do śledzenia przesyłki lub otwórz go bezpośrednio, aby natychmiast dodać paczkę.
 - 💬 Powiadomienia: Otrzymuj powiadomienia za każdym razem, gdy paczka dotrze dalej.
 - 🚫 Żadnych reklam i innych irytacji.
 - 👥 Darmowe i otwarte oprogramowanie: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/pl-PL/full_description.txt
+++ b/fastlane/metadata/android/pl-PL/full_description.txt
@@ -3,7 +3,6 @@
 Niektóre funkcje Deliveries:
 
 - 📱 Prosty i przejrzysty interfejs: Skup się wyłącznie na paczkach, a nie na tym, jak korzystać z aplikacji.
-- 🔗 Szybkie dodawanie: udostępnij link do śledzenia przesyłki w sekcji „Dostawy” lub otwórz go bezpośrednio, aby natychmiast dodać paczkę.
 - 💬 Powiadomienia: Otrzymuj powiadomienia za każdym razem, gdy paczka dotrze dalej.
 - 🚫 Żadnych reklam i innych irytacji.
 - 👥 Darmowe i otwarte oprogramowanie: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/ro/full_description.txt
+++ b/fastlane/metadata/android/ro/full_description.txt
@@ -3,7 +3,6 @@
 Câteva dintre caracteristicile aplicației Deliveries:
 
 - 📱 Interfață curată și simplă: Concentrează-te doar pe coletele tale, nu pe cum să folosești aplicația.
-- 🔗 Adăugare rapidă: partajează un link de urmărire în secțiunea „Livrări” sau deschide unul direct pentru a adăuga instantaneu un colet.
 - 💬 Notificări: Primește notificări de fiecare dată când un colet primește o nouă actualizare.
 - 🚫 Fără reclame sau alte neplăceri.
 - 👥 Gratuit și open source: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/ro/full_description.txt
+++ b/fastlane/metadata/android/ro/full_description.txt
@@ -3,6 +3,7 @@
 Câteva dintre caracteristicile aplicației Deliveries:
 
 - 📱 Interfață curată și simplă: Concentrează-te doar pe coletele tale, nu pe cum să folosești aplicația.
+- 🔗 Adăugare rapidă: partajează un link de urmărire către aplicația Deliveries sau deschide unul direct pentru a adăuga un colet instantaneu.
 - 💬 Notificări: Primește notificări de fiecare dată când un colet primește o nouă actualizare.
 - 🚫 Fără reclame sau alte neplăceri.
 - 👥 Gratuit și open source: https://github.com/itsvic-dev/parcel

--- a/fastlane/metadata/android/ro/full_description.txt
+++ b/fastlane/metadata/android/ro/full_description.txt
@@ -3,6 +3,7 @@
 Câteva dintre caracteristicile aplicației Deliveries:
 
 - 📱 Interfață curată și simplă: Concentrează-te doar pe coletele tale, nu pe cum să folosești aplicația.
+- 🔗 Adăugare rapidă: partajează un link de urmărire în secțiunea „Livrări” sau deschide unul direct pentru a adăuga instantaneu un colet.
 - 💬 Notificări: Primește notificări de fiecare dată când un colet primește o nouă actualizare.
 - 🚫 Fără reclame sau alte neplăceri.
 - 👥 Gratuit și open source: https://github.com/itsvic-dev/parcel


### PR DESCRIPTION
Adds two ways to start tracking a parcel from a link instead of typing it in manually:

- **Share target**: share a tracking URL from a browser/email/etc, pick "Deliveries", and land on Add Parcel with the courier and tracking ID (and postal code, where required) pre-filled.
- **App Links**: add supported courier tracking domains via Settings → Apps → Deliveries → "Open by default" → "Add link", so tapping a link elsewhere opens Deliveries directly to the same pre-filled form instead of a browser.

Currently supported: **DHL Parcel NL, UPS, GLS, InPost PL, PostNL, Poczta Polska**, all verified against a real tracking link (by me or a public example). Links to an unsupported provider still opens a blank Add Parcel form rather than doing nothing.

I was only able to add URL parsing for services I had access to, which is why the list of supported providers is currently limited. If you’re willing to share a redacted shipping/tracking URL from another provider, I can use it to add and verify support for more services.

Closes #94
Closes #227