### PR TITLE
feat: gls netherlands support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Europe:
 - DPD Poland
 - FOXPOST (HU)
 - GLS Hungary
+- GLS Netherlands
 - Hermes (DE)
 - InPost (PL)
 - Magyar Posta (HU)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -39,6 +39,7 @@ enum class Service {
   DPD_PL,
   FOXPOST,
   GLS_HUNGARY,
+  GLS_NETHERLANDS,
   HERMES,
   MAGYAR_POSTA,
   NOVA_POSHTA,
@@ -87,6 +88,7 @@ fun getDeliveryService(service: Service): DeliveryService? {
     Service.DPD_PL -> DpdPlDeliveryService
     Service.FOXPOST -> FoxpostDeliveryService
     Service.GLS_HUNGARY -> GLSHungaryDeliveryService
+    Service.GLS_NETHERLANDS -> GLSNetherlandsDeliveryService
     Service.HERMES -> HermesDeliveryService
     Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
     Service.NOVA_POSHTA -> NovaPostDeliveryService

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.api
+
+import android.os.LocaleList
+import com.squareup.moshi.JsonClass
+import dev.itsvic.parceltracker.R
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+// gls-group.eu doesn't have tracking data for parcels handled by GLS Netherlands; gls-info.nl
+// does, using an entirely different, reverse-engineered private API.
+object GLSNetherlandsDeliveryService : DeliveryService {
+  override val nameResource: Int = R.string.service_gls_netherlands
+  override val acceptsPostCode: Boolean = true
+  override val requiresPostCode: Boolean = true
+
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    // the site only ships nl and en translations; anything else falls back to English
+    val culture = if (LocaleList.getDefault().get(0).language == "nl") "nl-NL" else "en-GB"
+    val postalCode = postCode!!.replace(" ", "").uppercase()
+
+    val resp =
+        try {
+          service.getParcelDetails(id = trackingId, postalCode = postalCode, locale = culture)
+        } catch (_: HttpException) {
+          throw ParcelNonExistentException()
+        }
+
+    val history =
+        resp.scans.reversed().map {
+          ParcelHistoryItem(
+              it.eventReasonDescr,
+              LocalDateTime.parse(it.dateTime),
+              when {
+                it.depotName != null && it.depotName != "-" && it.countryName != null ->
+                    "${it.depotName}, ${it.countryName}"
+                it.depotName != null && it.depotName != "-" -> it.depotName
+                it.countryName != null -> it.countryName
+                else -> ""
+              })
+        }
+
+    val status =
+        when (resp.state) {
+          State.ANNOUNCED -> Status.Preadvice
+          State.RECEIVED -> Status.PickedUpByCourier
+          State.IN_REGION -> Status.InWarehouse
+          State.OUT_FOR_DELIVERY -> Status.OutForDelivery
+          State.DELIVERED ->
+              when (resp.subState) {
+                SubState.DELIVERED_AT_NEIGHBORS -> Status.DeliveredToNeighbor
+                SubState.DELIVERED_AT_PARCEL_SHOP,
+                SubState.DELIVERED_AT_APL -> Status.AwaitingPickup
+                SubState.COLLECTED_FROM_PARCEL_SHOP,
+                SubState.COLLECTED_FROM_APL,
+                SubState.PICKUP_COLLECTED -> Status.PickedUp
+                else -> Status.Delivered
+              }
+          State.NOT_DELIVERED -> Status.DeliveryFailure
+          State.RETURN ->
+              if (resp.subState == SubState.RETURNED_TO_SENDER) Status.ReturnedToSender
+              else Status.ReturningToSender
+          State.IN_LOCKER -> Status.AwaitingPickup
+          else ->
+              logUnknownStatus("GLS Netherlands", "state=${resp.state} subState=${resp.subState}")
+        }
+
+    val properties = mutableMapOf<Int, String>()
+
+    (resp.weighedWeight ?: resp.suppliedWeight)?.let {
+      properties[R.string.property_weight] = "$it kg"
+    }
+
+    val deliveryTime = resp.deliveryScanInfo?.dateTime
+    val eta = resp.deliveryStatus?.etaTimestamp
+    if (status == Status.Delivered && deliveryTime != null) {
+      properties[R.string.property_delivery_time] =
+          LocalDateTime.parse(deliveryTime)
+              .format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+    } else if (eta != null) {
+      properties[R.string.property_eta] =
+          LocalDateTime.parse(eta).format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+    }
+
+    return Parcel(trackingId, history, status, properties)
+  }
+
+  // https://apm.gls.nl parcel state/sub-state enums, taken from gls-info.nl's frontend bundle
+  private object State {
+    const val ANNOUNCED = 0
+    const val RECEIVED = 1
+    const val IN_REGION = 2
+    const val OUT_FOR_DELIVERY = 3
+    const val DELIVERED = 4
+    const val NOT_DELIVERED = 5
+    const val RETURN = 6
+    const val IN_LOCKER = 7
+  }
+
+  private object SubState {
+    const val DELIVERED_AT_NEIGHBORS = 2
+    const val DELIVERED_AT_PARCEL_SHOP = 3
+    const val RETURNED_TO_SENDER = 6
+    const val DELIVERED_AT_APL = 7
+    const val COLLECTED_FROM_APL = 9
+    const val COLLECTED_FROM_PARCEL_SHOP = 10
+    const val PICKUP_COLLECTED = 14
+  }
+
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://apm.gls.nl/api/tracktrace/v1/")
+          .client(api_client)
+          .addConverterFactory(api_factory)
+          .build()
+  private val service = retrofit.create(API::class.java)
+
+  private interface API {
+    @GET("{id}/postalcode/{postalCode}/details/{locale}")
+    suspend fun getParcelDetails(
+        @Path("id") id: String,
+        @Path("postalCode") postalCode: String,
+        @Path("locale") locale: String,
+    ): ParcelDetails
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelDetails(
+      val state: Int,
+      val subState: Int,
+      val scans: List<Scan>,
+      val weighedWeight: Double?,
+      val suppliedWeight: Double?,
+      val deliveryStatus: DeliveryStatus?,
+      val deliveryScanInfo: DeliveryScanInfo?,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class Scan(
+      val dateTime: String,
+      val eventReasonDescr: String,
+      val depotName: String?,
+      val countryName: String?,
+  )
+
+  @JsonClass(generateAdapter = true) internal data class DeliveryStatus(val etaTimestamp: String?)
+
+  @JsonClass(generateAdapter = true)
+  internal data class DeliveryScanInfo(val isDelivered: Boolean, val dateTime: String?)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
   <string name="service_foxpost" translatable="false">FOXPOST</string>
   <string name="service_gls" translatable="false">GLS</string>
   <string name="service_gls_hungary">GLS Hungary</string>
+  <string name="service_gls_netherlands">GLS Netherlands</string>
   <string name="service_hermes" translatable="false">Hermes</string>
   <string name="service_hungarian_post">Hungarian Post</string>
   <string name="service_inpost">InPost (Poland)</string>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -32,6 +32,7 @@ Europe:
 - An Post (IE)
 - Belpost (BY)
 - GLS Hungary
+- GLS Netherlands
 - Hermes (DE)
 - InPost (PL)
 - Magyar Posta (HU)


### PR DESCRIPTION
Add support for gls netherlands

T&t parcel id is the same as gls but they're two seperate backends.
For example my parcel only shows up on `https://www.gls-info.nl/tracking/ttlink?parcelNo=00000000000000&zipCode=1234AB&lang=NL` but not on `https://gls-group.eu/EU/en/parcel-tracking?match=00000000000000`

Reverse-engineered from gls-info.nl's frontend which had a mapping of all possible states so this should cover everyhing