### PR TITLE
fix: handle ISO timestamps with time zones

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/AllegroOneBoxDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AllegroOneBoxDeliveryService.kt
@@ -3,9 +3,6 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.Instant
-import java.time.LocalDateTime
-import java.util.TimeZone
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -110,8 +107,7 @@ object AllegroOneBoxDeliveryService : DeliveryService {
     return events.map { item ->
       ParcelHistoryItem(
           item.description,
-          LocalDateTime.ofInstant(
-              Instant.parse(item.eventTimestamp), TimeZone.getDefault().toZoneId()),
+          localDateFromISO(item.eventTimestamp),
           "" // the API doesn't provide us any locations :(
           )
     }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
@@ -3,8 +3,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.Body
@@ -106,10 +104,7 @@ object AnPostDeliveryService : DeliveryService {
 
     val events =
         resp.getEventsResponse.GetEventsResult.map {
-          ParcelHistoryItem(
-              it.activity,
-              LocalDateTime.parse(it.date, DateTimeFormatter.ISO_DATE_TIME),
-              it.location)
+          ParcelHistoryItem(it.activity, localDateFromISO(it.date), it.location)
         }
 
     val status = mapTraceCode(resp.getEventsResponse.GetEventsResult.first().traceCode)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/BelpostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/BelpostDeliveryService.kt
@@ -3,9 +3,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.Instant
-import java.time.LocalDateTime
-import java.util.TimeZone
 import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -31,10 +28,7 @@ object BelpostDeliveryService : DeliveryService {
     val history =
         resp.data[0].steps.map { item ->
           ParcelHistoryItem(
-              item.event,
-              LocalDateTime.ofInstant(
-                  Instant.ofEpochSecond(item.timestamp.toLong()), TimeZone.getDefault().toZoneId()),
-              item.place)
+              item.event, localDateFromMilli(item.timestamp.toLong() * 1000), item.place)
         }
 
     /*

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -9,6 +9,8 @@ import dev.itsvic.parceltracker.BuildConfig
 import dev.itsvic.parceltracker.R
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.TimeZone
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -217,4 +219,18 @@ internal fun logUnknownStatus(service: String, data: String): Status {
 
 fun localDateFromMilli(milli: Long): LocalDateTime {
   return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), TimeZone.getDefault().toZoneId())
+}
+
+/**
+ * Parses an ISO-8601 date-time whose offset is optional. APIs are inconsistent about this: the same
+ * response can mix offset-less timestamps ("2026-08-17T07:47:32") with offset-bearing ones
+ * ("2026-08-17T11:26:00+02:00"), which LocalDateTime.parse alone rejects. Timestamps carrying an
+ * offset or zone get converted into the device's time zone; the rest are taken as local time.
+ */
+fun localDateFromISO(dateTime: String): LocalDateTime {
+  val parsed =
+      DateTimeFormatter.ISO_DATE_TIME.parseBest(dateTime, ZonedDateTime::from, LocalDateTime::from)
+  return if (parsed is ZonedDateTime)
+      parsed.withZoneSameInstant(TimeZone.getDefault().toZoneId()).toLocalDateTime()
+  else parsed as LocalDateTime
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/DhlDeliveryService.kt
@@ -7,8 +7,6 @@ import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.DHL_API_KEY
 import dev.itsvic.parceltracker.R
 import dev.itsvic.parceltracker.dataStore
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.first
 import retrofit2.HttpException
 import retrofit2.Retrofit
@@ -81,7 +79,7 @@ object DhlDeliveryService : DeliveryService {
         shipment.events.map {
           ParcelHistoryItem(
               it.description ?: it.status,
-              LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
+              localDateFromISO(it.timestamp),
               if (it.location == null) "Unknown location"
               else if (it.location.address.postalCode != null)
                   "${it.location.address.postalCode} ${it.location.address.addressLocality}"

--- a/app/src/main/java/dev/itsvic/parceltracker/api/DpdUkDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/DpdUkDeliveryService.kt
@@ -4,8 +4,6 @@ package dev.itsvic.parceltracker.api
 import android.util.Log
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -32,7 +30,7 @@ object DpdUkDeliveryService : DeliveryService {
         events.data.map {
           ParcelHistoryItem(
               it.eventText,
-              LocalDateTime.parse(it.eventDate.replace(' ', 'T'), DateTimeFormatter.ISO_DATE_TIME),
+              localDateFromISO(it.eventDate.replace(' ', 'T')),
               it.eventLocation,
           )
         }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/EvriDeliveryService.kt
@@ -3,8 +3,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.Instant
-import java.time.ZoneId
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -35,10 +33,7 @@ object EvriDeliveryService : DeliveryService {
 
     val history =
         parcel.trackingEvents.map {
-          ParcelHistoryItem(
-              it.trackingPoint.description,
-              Instant.parse(it.dateTime).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-              "")
+          ParcelHistoryItem(it.trackingPoint.description, localDateFromISO(it.dateTime), "")
         }
 
     val status =

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSDeliveryService.kt
@@ -5,8 +5,6 @@ import android.os.LocaleList
 import android.text.Html
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -37,7 +35,7 @@ open class GLSDeliveryService(override val nameResource: Int, region: String) : 
         resp.history.map { item ->
           ParcelHistoryItem(
               Html.fromHtml(item.evtDscr, Html.FROM_HTML_MODE_LEGACY).toString(),
-              LocalDateTime.parse("${item.date}T${item.time}", DateTimeFormatter.ISO_DATE_TIME),
+              localDateFromISO("${item.date}T${item.time}"),
               when {
                 item.address.countryName == null && item.address.city.isNotEmpty() ->
                     item.address.city

--- a/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/GLSNetherlandsDeliveryService.kt
@@ -4,7 +4,6 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import retrofit2.HttpException
@@ -35,14 +34,15 @@ object GLSNetherlandsDeliveryService : DeliveryService {
         resp.scans.reversed().map {
           ParcelHistoryItem(
               it.eventReasonDescr,
-              LocalDateTime.parse(it.dateTime),
+              localDateFromISO(it.dateTime),
               when {
                 it.depotName != null && it.depotName != "-" && it.countryName != null ->
                     "${it.depotName}, ${it.countryName}"
                 it.depotName != null && it.depotName != "-" -> it.depotName
                 it.countryName != null -> it.countryName
                 else -> ""
-              })
+              },
+          )
         }
 
     val status =
@@ -80,11 +80,11 @@ object GLSNetherlandsDeliveryService : DeliveryService {
     val eta = resp.deliveryStatus?.etaTimestamp
     if (status == Status.Delivered && deliveryTime != null) {
       properties[R.string.property_delivery_time] =
-          LocalDateTime.parse(deliveryTime)
+          localDateFromISO(deliveryTime)
               .format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
     } else if (eta != null) {
       properties[R.string.property_eta] =
-          LocalDateTime.parse(eta).format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+          localDateFromISO(eta).format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
     }
 
     return Parcel(trackingId, history, status, properties)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/HermesDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/HermesDeliveryService.kt
@@ -3,8 +3,6 @@ package dev.itsvic.parceltracker.api
 import android.content.Context
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -52,10 +50,7 @@ object HermesDeliveryService : DeliveryService {
 
     val history =
         statusReached.map {
-          ParcelHistoryItem(
-              it.historyText!!,
-              LocalDateTime.parse(it.timestamp, DateTimeFormatter.ISO_DATE_TIME),
-              "")
+          ParcelHistoryItem(it.historyText!!, localDateFromISO(it.timestamp!!), "")
         }
 
     return Parcel(trackingId, history, status)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostDeliveryService.kt
@@ -6,8 +6,6 @@ package dev.itsvic.parceltracker.api
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -123,7 +121,7 @@ object InPostDeliveryService : DeliveryService {
       details.map { item ->
         ParcelHistoryItem(
             item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
-            LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+            localDateFromISO(item.datetime),
             item.location ?: item.agency ?: "",
         )
       }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/InPostItalyDeliveryService.kt
@@ -6,8 +6,6 @@ package dev.itsvic.parceltracker.api
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -110,7 +108,7 @@ object InPostItalyDeliveryService : DeliveryService {
       details.map { item ->
         ParcelHistoryItem(
             item.status.replace('_', ' ').replaceFirstChar { it.uppercase() },
-            LocalDateTime.parse(item.datetime, DateTimeFormatter.ISO_DATE_TIME),
+            localDateFromISO(item.datetime),
             item.agency ?: "",
         )
       }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/MagyarPostaDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/MagyarPostaDeliveryService.kt
@@ -3,9 +3,6 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.Instant
-import java.time.LocalDateTime
-import java.util.TimeZone
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -44,10 +41,7 @@ object MagyarPostaDeliveryService : DeliveryService {
     val history =
         events.map {
           ParcelHistoryItem(
-              it.tranzakcioTipusLeiras,
-              LocalDateTime.ofInstant(
-                  Instant.ofEpochMilli(it.time), TimeZone.getDefault().toZoneId()),
-              it.postaNev.replace('|', '\n'))
+              it.tranzakcioTipusLeiras, localDateFromMilli(it.time), it.postaNev.replace('|', '\n'))
         }
 
     val category = events.first().tranzakcioKategoriaKod

--- a/app/src/main/java/dev/itsvic/parceltracker/api/NovaPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/NovaPostDeliveryService.kt
@@ -2,8 +2,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -29,12 +27,7 @@ object NovaPostDeliveryService : DeliveryService {
 
     val history =
         resp.tracking.reversed().map {
-          ParcelHistoryItem(
-              it.event_name,
-              ZonedDateTime.parse(it.date)
-                  .withZoneSameInstant(ZoneId.systemDefault())
-                  .toLocalDateTime(),
-              it.settlement_name)
+          ParcelHistoryItem(it.event_name, localDateFromISO(it.date), it.settlement_name)
         }
 
     // very crude guesswork. Nova Post does not make this easy at all lol

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PacketaDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PacketaDeliveryService.kt
@@ -4,8 +4,6 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import okio.IOException
 import retrofit2.HttpException
 import retrofit2.Retrofit
@@ -39,7 +37,7 @@ object PacketaDeliveryService : DeliveryService {
         resp.item.trackingDetails.reversed().map {
           ParcelHistoryItem(
               it.text,
-              LocalDateTime.parse(it.time.replace(' ', 'T'), DateTimeFormatter.ISO_DATE_TIME),
+              localDateFromISO(it.time.replace(' ', 'T')),
               // location is not its own field, and regex is unreliable
               // as addresses are just tacked on the end with inconsistent formatting
               "")

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PolishPostDeliveryService.kt
@@ -4,8 +4,6 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.Headers
@@ -37,7 +35,7 @@ object PolishPostDeliveryService : DeliveryService {
         resp.mailInfo.events.reversed().map { item ->
           ParcelHistoryItem(
               item.name,
-              LocalDateTime.parse(item.time, DateTimeFormatter.ISO_DATE_TIME),
+              localDateFromISO(item.time),
               if (item.postOffice.description != null)
                   "${item.postOffice.name}\n${item.postOffice.description.street} ${item.postOffice.description.houseNumber}\n${item.postOffice.description.zipCode} ${item.postOffice.description.city}"
               else item.postOffice.name)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
@@ -4,8 +4,6 @@ import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
 import java.io.IOException
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -68,9 +66,7 @@ object PostNordDeliveryService : DeliveryService {
 
           ParcelHistoryItem(
               event.eventDescription,
-              ZonedDateTime.parse(event.eventTime)
-                  .withZoneSameInstant(ZoneId.systemDefault())
-                  .toLocalDateTime(),
+              localDateFromISO(event.eventTime),
               listOfNotNull(locationName, locationCountryCode).joinToString(", "))
         }
 

--- a/app/src/main/java/dev/itsvic/parceltracker/api/PosteItalianeDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PosteItalianeDeliveryService.kt
@@ -3,9 +3,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.Instant
-import java.time.LocalDateTime
-import java.util.TimeZone
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.Body
@@ -35,8 +32,7 @@ object PosteItalianeDeliveryService : DeliveryService {
         resp.listaMovimenti.reversed().map {
           ParcelHistoryItem(
               it.statoLavorazione,
-              LocalDateTime.ofInstant(
-                  Instant.ofEpochMilli(it.dataOra), TimeZone.getDefault().toZoneId()),
+              localDateFromMilli(it.dataOra),
               it.luogo,
           )
         }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/SPXDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/SPXDeliveryService.kt
@@ -4,9 +4,6 @@ package dev.itsvic.parceltracker.api
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
 import java.security.MessageDigest
-import java.time.Instant
-import java.time.LocalDateTime
-import java.util.TimeZone
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -49,8 +46,7 @@ open class SPXDeliveryService(
           ParcelHistoryItem(
               // shit patch for their shit bug
               it.message.replace("\\\\n", ""),
-              LocalDateTime.ofInstant(
-                  Instant.ofEpochMilli(it.timestamp * 1000L), TimeZone.getDefault().toZoneId()),
+              localDateFromMilli(it.timestamp * 1000L),
               "")
         }
 

--- a/app/src/main/java/dev/itsvic/parceltracker/api/SamedayDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/SamedayDeliveryService.kt
@@ -3,8 +3,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -33,11 +31,7 @@ open class SamedayDeliveryService(region: String, override val nameResource: Int
         resp.awbHistory.map {
           ParcelHistoryItem(
               it.status,
-              // i'm sure there's a more concise way of doing this
-              ZonedDateTime.parse(it.statusDate)
-                  .toInstant()
-                  .atZone(ZoneId.systemDefault())
-                  .toLocalDateTime(),
+              localDateFromISO(it.statusDate),
               if (it.transitLocation.isNotBlank())
                   "${it.transitLocation}, ${it.county}, ${it.country}"
               else if (it.county.isNotBlank()) "${it.county}, ${it.country}"

--- a/app/src/main/java/dev/itsvic/parceltracker/api/UkrposhtaDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/UkrposhtaDeliveryService.kt
@@ -2,7 +2,6 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import java.time.LocalDateTime
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.http.GET
@@ -30,7 +29,7 @@ object UkrposhtaDeliveryService : DeliveryService {
 
     val history =
         resp.reversed().map {
-          ParcelHistoryItem(it.eventName, LocalDateTime.parse(it.date), "${it.name}, ${it.country}")
+          ParcelHistoryItem(it.eventName, localDateFromISO(it.date), "${it.name}, ${it.country}")
         }
 
     val status =

--- a/app/src/test/java/dev/itsvic/parceltracker/api/DateParsingTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/DateParsingTest.kt
@@ -1,0 +1,54 @@
+import dev.itsvic.parceltracker.api.localDateFromISO
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.TimeZone
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DateParsingTest {
+  private fun expectedInZone(instant: String): LocalDateTime =
+      ZonedDateTime.parse(instant).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()
+
+  @Test
+  fun localDateFromISO_offsetlessIsTakenAsLocalTime() {
+    assertEquals(LocalDateTime.of(2026, 8, 17, 7, 47, 32), localDateFromISO("2026-08-17T07:47:32"))
+  }
+
+  @Test
+  fun localDateFromISO_fractionalSecondsAreAccepted() {
+    assertEquals(
+        LocalDateTime.of(2026, 8, 14, 11, 52, 1, 878_000_000),
+        localDateFromISO("2026-08-14T11:52:01.878"),
+    )
+  }
+
+  // GLS Netherlands returns the delivery ETA with an offset while every other timestamp in the
+  // same response has none.
+  @Test
+  fun localDateFromISO_offsetIsConvertedToDeviceZone() {
+    assertEquals(
+        expectedInZone("2026-08-17T11:26:00+02:00"),
+        localDateFromISO("2026-08-17T11:26:00+02:00"),
+    )
+  }
+
+  @Test
+  fun localDateFromISO_zuluIsConvertedToDeviceZone() {
+    assertEquals(expectedInZone("2026-08-17T00:00:00Z"), localDateFromISO("2026-08-17T00:00:00Z"))
+  }
+
+  @Test
+  fun localDateFromISO_zoneRegionIsConvertedToDeviceZone() {
+    val default = TimeZone.getDefault()
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+      assertEquals(
+          LocalDateTime.of(2026, 8, 17, 9, 26, 0),
+          localDateFromISO("2026-08-17T11:26:00+02:00[Europe/Amsterdam]"),
+      )
+    } finally {
+      TimeZone.setDefault(default)
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #235.

GLS Netherlands mixes two timestamp shapes in one response:

```json
"scans": [{ "dateTime": "2026-08-17T07:47:32" }],
"deliveryStatus": { "etaTimestamp": "2026-08-17T11:26:00+02:00" }
```

`LocalDateTime.parse()` with no formatter uses `ISO_LOCAL_DATE_TIME`, which rejects the
offset. The `DateTimeParseException` hits the catch-all in `MainActivity` and the parcel
shows an error instead of tracking info. The `deliveryStatus` block only exists while a
parcel is out for delivery, which is why it wasn't caught earlier.

Adds `localDateFromISO()` to `Core.kt`:
* Offset or zone present -> converted to the device's TZ
* Absent -> local time as before

Applied it to every service parsing an ISO timestamp. One other, Ukrposhta, had the same
issue; nine silently dropped the offset and showed carrier wall-clock time; five already
did it correctly by hand and are now just shorter. Cainiao (deliberately uses the parcel's
own zone), UPS, and the non-ISO parsers are untouched.

Tests cover offsetless, fractional seconds, `+02:00`, `Z` and a bracketed zone. Unit suite
and `assembleDebug` pass, ran ktfmt.
